### PR TITLE
Styling changes for nested questionnaire groups

### DIFF
--- a/components/clinical/questionnaire/src/molecules/question-group.tsx
+++ b/components/clinical/questionnaire/src/molecules/question-group.tsx
@@ -10,14 +10,12 @@ import {
 import QuestionBlock from './question-block'
 
 const StyledQuestionGroup = styled.div`
+  border: solid 2px #ccc;
+  border-radius: 0.25rem;
+  margin-bottom: 1rem;
   flex-basis: 100%;
   display: flex;
   flex-direction: column;
-
-  border-bottom: 1px solid rgba(0, 0, 0, 0.125);
-  &:last-of-type {
-    border-bottom: none;
-  }
 
   .QuestionBlock {
     padding-left: 0.5rem;
@@ -32,7 +30,6 @@ const GroupHeader = styled.h3`
 `
 
 const StyledGroupBlock = styled.div`
-  background: #eaeaea;
   flex: 2;
   display: flex;
   flex-wrap: wrap;

--- a/components/clinical/questionnaire/src/organisms/questionnaire.tsx
+++ b/components/clinical/questionnaire/src/organisms/questionnaire.tsx
@@ -27,12 +27,11 @@ const QuestionContainer = styled.div`
 
   > div.QuestionBlock,
   > div.QuestionGroup {
-    padding: 0.5rem 2rem 0.5rem 0;
-    border-bottom: none;
   }
 
   > div.QuestionGroup {
     flex-basis: 100%;
+    border: none;
   }
 
   dl > dt {


### PR DESCRIPTION
Swap out grey background (bad for contrast, breaks up the flow of the card / widget) for borders