### PR TITLE
Export the ITimelineItem interface properly

### DIFF
--- a/components/clinical/timeline/src/index.tsx
+++ b/components/clinical/timeline/src/index.tsx
@@ -1,5 +1,5 @@
 import Timeline from './organisms/timeline'
-import ITimelineItem from './molecules/timeline-item'
+import { ITimelineItem } from './molecules/timeline-item'
 
 export default Timeline
 export { ITimelineItem }


### PR DESCRIPTION
In the Index file we were accidentally importing the default item which is the component, then exporting it and expecting it to be the interface. This PR corrects the import so that what we actually export from the Index file is the interface we need in ehr-client.