### PR TITLE
Task/add format date time func to library

### DIFF
--- a/packages/utils/src/atoms/partial-date-time.test.ts
+++ b/packages/utils/src/atoms/partial-date-time.test.ts
@@ -1,5 +1,5 @@
 import { PartialDateTime, PartialDateTimeKindCode } from '@ltht-react/types'
-import { partialDateTimeText } from './partial-date-time'
+import { formatDateTime, partialDateTimeText } from './partial-date-time'
 
 describe('partialDateTimeText', () => {
   // it('formats date correctly', () => {
@@ -21,6 +21,16 @@ describe('partialDateTimeText', () => {
   it('formats year-month correctly', () => {
     const date = partialDateTime(PartialDateTimeKindCode.YearMonth)
     expect(partialDateTimeText(date)).toEqual('Feb-2013')
+  })
+
+  it('formats dateTimes correctly', () => {
+    const date = new Date(2022, 0, 10, 9, 47)
+    expect(formatDateTime(date)).toEqual('10 January 2022 : 09:47')
+  })
+
+  it('formats dateTimes without seconds or milliseconds', () => {
+    const date = new Date(2022, 0, 10, 9, 47, 10, 10)
+    expect(formatDateTime(date)).toEqual('10 January 2022 : 09:47')
   })
 })
 

--- a/packages/utils/src/atoms/partial-date-time.test.ts
+++ b/packages/utils/src/atoms/partial-date-time.test.ts
@@ -32,6 +32,11 @@ describe('partialDateTimeText', () => {
     const date = new Date(2022, 0, 10, 9, 47, 10, 10)
     expect(formatDateTime(date)).toEqual('10 January 2022 : 09:47')
   })
+
+  it('formats DateTimes as midnight by default if no time is provided', () => {
+    const date = new Date(2022, 0, 10)
+    expect(formatDateTime(date)).toEqual('10 January 2022 : 00:00')
+  })
 })
 
 const dateValue = '2013-02-03T13:15:16+00:00'

--- a/packages/utils/src/atoms/partial-date-time.ts
+++ b/packages/utils/src/atoms/partial-date-time.ts
@@ -17,6 +17,10 @@ export const formatDateExplicitMonth = (date: Date): string =>
 export const formatTime = (date: Date): string =>
   date.toLocaleString(locale, { hour: hourFormat, minute: minuteFormat, hour12: false }).split(' ').join(':')
 
+export const formatDateTime = (date: Date): string => {
+  return `${formatDateExplicitMonth(date)} : ${formatTime(date)}`
+}
+
 export const partialDateTimeText = (partialDateTime?: PartialDateTime | null): string => {
   if (!partialDateTime || !partialDateTime.value) {
     return ''


### PR DESCRIPTION
We wrote a function during work on ehr-client that should really live in ehr-ltht. 
This PR introduces a formatDateTime function which chains two pre-existing library methods, formatDateExplicitMonth and formatTime.