### PR TITLE
Fix: Hide question block title if no sub answers

### DIFF
--- a/components/clinical/questionnaire/src/molecules/question-group.tsx
+++ b/components/clinical/questionnaire/src/molecules/question-group.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react'
+import { FC } from 'react'
 import styled from '@emotion/styled'
 import {
   DetailViewType,
@@ -35,49 +35,64 @@ const StyledGroupBlock = styled.div`
   justify-content: flex-start;
 `
 
-function QuestionnaireQuestions(
-  questions: Maybe<Maybe<QuestionnaireItem>[]> | undefined,
-  answers: Maybe<Maybe<QuestionnaireResponseItem>[]> | undefined,
-  viewType: DetailViewType
-): ReactNode {
-  return questions?.map((question) => {
-    if (question?.type === QuestionnaireItemTypeCode.Group) {
-      const groupAnswers = answers
-        ?.filter((answerGroup) => question?.linkId === answerGroup?.linkId)
-        .map((answerGroup) => answerGroup?.item)
+const QuestionnaireQuestions: FC<IQuestionnaireQuestionsProps> = ({
+  questions,
+  answers,
+  viewType = DetailViewType.Compact,
+}) => (
+  <>
+    {questions?.map((question) => {
+      if (question?.type === QuestionnaireItemTypeCode.Group) {
+        const groupAnswers = answers
+          ?.filter((answerGroup) => question?.linkId === answerGroup?.linkId)
+          .map((answerGroup) => answerGroup?.item)
 
-      return groupAnswers?.map((groupAnswer, index) => (
-        <QuestionGroup
-          key={`${question?.text || 'question-group'}-${question?.linkId}-${index + 1}`}
-          header={question.text}
-          questions={question.item}
-          answers={groupAnswer}
-          viewType={viewType}
+        return groupAnswers?.map((groupAnswer, index) => (
+          <QuestionGroup
+            key={`${question?.text || 'question-group'}-${question?.linkId}-${index + 1}`}
+            header={question.text}
+            questions={question.item}
+            answers={groupAnswer}
+            viewType={viewType}
+          />
+        ))
+      }
+
+      return (
+        <QuestionBlock
+          className="QuestionBlock"
+          key={`${question?.text}-${question?.linkId}`}
+          type={question?.type}
+          question={question?.text}
+          responseItem={answers?.find((answer) => question?.linkId === answer?.linkId)}
+          showIfEmpty={viewType === DetailViewType.Expanded}
         />
-      ))
-    }
-
-    return (
-      <QuestionBlock
-        className="QuestionBlock"
-        key={`${question?.text}-${question?.linkId}`}
-        type={question?.type}
-        question={question?.text}
-        responseItem={answers?.find((answer) => question?.linkId === answer?.linkId)}
-        showIfEmpty={viewType === DetailViewType.Expanded}
-      />
-    )
-  })
-}
+      )
+    })}
+  </>
+)
 
 const QuestionGroup: FC<IProps> = ({ header, questions, answers, viewType = DetailViewType.Compact, className }) => {
-  if (answers?.length === 0) return null
+  if (answers?.length === 0) return <></>
 
+  // if the answers exist but do not contain values, return a fragment
+  if (
+    viewType === DetailViewType.Compact &&
+    answers?.some((x) => {
+      const hasText = !!x?.text
+      const hasAnswers = !!x?.answer?.length
+      const hasItems = !!x?.item?.length
+
+      return hasText || hasAnswers || hasItems
+    }) === false
+  ) {
+    return <></>
+  }
   return (
     <StyledQuestionGroup className={className}>
       {header && <GroupHeader>{header}</GroupHeader>}
       <StyledGroupBlock>
-        {QuestionnaireQuestions(questions, answers, viewType ?? DetailViewType.Compact)}
+        <QuestionnaireQuestions questions={questions} answers={answers} viewType={viewType ?? DetailViewType.Compact} />
       </StyledGroupBlock>
     </StyledQuestionGroup>
   )
@@ -89,6 +104,12 @@ interface IProps {
   answers?: Maybe<Maybe<QuestionnaireResponseItem>[]>
   viewType?: Maybe<DetailViewType>
   className?: string
+}
+
+interface IQuestionnaireQuestionsProps {
+  questions: Maybe<Maybe<QuestionnaireItem>[]> | undefined
+  answers: Maybe<Maybe<QuestionnaireResponseItem>[]> | undefined
+  viewType?: Maybe<DetailViewType>
 }
 
 export default QuestionGroup

--- a/components/clinical/questionnaire/src/organisms/questionnaire.tsx
+++ b/components/clinical/questionnaire/src/organisms/questionnaire.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react'
+import { FC } from 'react'
 import styled from '@emotion/styled'
 import {
   QuestionnaireResponse,
@@ -39,41 +39,39 @@ const QuestionContainer = styled.div`
   }
 `
 
-function QuestionnaireQuestions(
-  questions: Maybe<Maybe<QuestionnaireItem>[]> | undefined,
-  answers: Maybe<Maybe<QuestionnaireResponseItem>[]> | undefined,
-  viewType?: Maybe<DetailViewType>
-): ReactNode {
-  return questions?.map((question) => {
-    if (question?.type === QuestionnaireItemTypeCode.Group) {
-      const groupAnswers = answers
-        ?.filter((answerGroup) => question.linkId === answerGroup?.linkId)
-        .map((answerGroup) => answerGroup?.item)
+const QuestionnaireQuestions: FC<IQuestionnaireQuestionsProps> = ({ questions, answers, viewType }) => (
+  <>
+    {questions?.map((question) => {
+      if (question?.type === QuestionnaireItemTypeCode.Group) {
+        const groupAnswers = answers
+          ?.filter((answerGroup) => question.linkId === answerGroup?.linkId)
+          .map((answerGroup) => answerGroup?.item)
 
-      return groupAnswers?.map((groupAnswer, index) => (
-        <QuestionGroup
-          className="QuestionGroup"
-          key={`${question?.text || 'question-group'}-${question?.linkId}-${index + 1}`}
-          header={question.text}
-          questions={question.item}
-          answers={groupAnswer}
-          viewType={viewType}
+        return groupAnswers?.map((groupAnswer, index) => (
+          <QuestionGroup
+            className="QuestionGroup"
+            key={`${question?.text || 'question-group'}-${question?.linkId}-${index + 1}`}
+            header={question.text}
+            questions={question.item}
+            answers={groupAnswer}
+            viewType={viewType}
+          />
+        ))
+      }
+
+      return (
+        <QuestionBlock
+          className="QuestionBlock"
+          key={`${question?.text}-${question?.linkId}`}
+          type={question?.type}
+          question={question?.text}
+          responseItem={answers?.find((answer) => question?.linkId === answer?.linkId)}
+          showIfEmpty={viewType === DetailViewType.Expanded}
         />
-      ))
-    }
-
-    return (
-      <QuestionBlock
-        className="QuestionBlock"
-        key={`${question?.text}-${question?.linkId}`}
-        type={question?.type}
-        question={question?.text}
-        responseItem={answers?.find((answer) => question?.linkId === answer?.linkId)}
-        showIfEmpty={viewType === DetailViewType.Expanded}
-      />
-    )
-  })
-}
+      )
+    })}
+  </>
+)
 
 const Questionnaire: FC<IProps> = ({ questionnaire, showTitle = false, viewType = DetailViewType.Compact }) => {
   const questions = questionnaire?.questionnaire?.item
@@ -85,7 +83,9 @@ const Questionnaire: FC<IProps> = ({ questionnaire, showTitle = false, viewType 
   return (
     <StyledQuestionnaire>
       {showTitle && <TitleInfo title={title} />}
-      <QuestionContainer>{QuestionnaireQuestions(questions, answers, viewType)}</QuestionContainer>
+      <QuestionContainer>
+        <QuestionnaireQuestions questions={questions} answers={answers} viewType={viewType} />
+      </QuestionContainer>
       <AuthorInfo author={questionnaire?.author} authoredOn={questionnaire?.authored} />
     </StyledQuestionnaire>
   )
@@ -94,6 +94,12 @@ const Questionnaire: FC<IProps> = ({ questionnaire, showTitle = false, viewType 
 interface IProps {
   questionnaire: Maybe<QuestionnaireResponse> | undefined
   showTitle?: boolean | undefined
+  viewType?: Maybe<DetailViewType>
+}
+
+interface IQuestionnaireQuestionsProps {
+  questions: Maybe<Maybe<QuestionnaireItem>[]> | undefined
+  answers: Maybe<Maybe<QuestionnaireResponseItem>[]> | undefined
   viewType?: Maybe<DetailViewType>
 }
 

--- a/packages/storybook/src/clinical/organisms/questionnaire/questionnaire.fixtures.tsx
+++ b/packages/storybook/src/clinical/organisms/questionnaire/questionnaire.fixtures.tsx
@@ -460,6 +460,23 @@ export const NoAnswerData: QuestionnaireResponse = {
         type: QuestionnaireItemTypeCode.QuestionBoolean,
         item: null,
       },
+      {
+        linkId: '2',
+        text: 'General questions',
+        type: QuestionnaireItemTypeCode.Group,
+        item: [
+          {
+            linkId: '2.1',
+            text: 'What is your gender?',
+            type: QuestionnaireItemTypeCode.QuestionString,
+          },
+          {
+            linkId: '2.2',
+            text: 'What is your date of birth?',
+            type: QuestionnaireItemTypeCode.QuestionDate,
+          },
+        ],
+      },
     ],
   },
   item: [
@@ -468,6 +485,23 @@ export const NoAnswerData: QuestionnaireResponse = {
       text: null,
       answer: [],
       item: null,
+    },
+    {
+      linkId: '2',
+      text: null,
+      answer: null,
+      item: [
+        {
+          linkId: '2.1',
+          text: null,
+          answer: [],
+        },
+        {
+          linkId: '2.2',
+          text: null,
+          answer: [],
+        },
+      ],
     },
   ],
 }

--- a/packages/storybook/src/clinical/organisms/questionnaire/questionnaire.fixtures.tsx
+++ b/packages/storybook/src/clinical/organisms/questionnaire/questionnaire.fixtures.tsx
@@ -1943,3 +1943,162 @@ export const MissingAnswersExampleData: QuestionnaireResponse = {
     },
   ],
 }
+
+export const DischargeDestinationExampleData: QuestionnaireResponse = {
+  id: '788c08bc-b8b6-4265-91eb-cf116ef63aba',
+  status: QuestionnaireResponseStatus.Completed,
+  authored: {
+    kind: PartialDateTimeKindCode.DateTime,
+    value: '2022-08-04T10:02:14.903+00:00',
+  },
+  author: {
+    typeName: 'EhrUser',
+    identifier: {
+      system: null,
+      value: '13b66ada-eee1-4084-b824-5aa3f2deb064',
+    },
+    display: 'SYKES, Michelle Project Nurse, The Leeds Teaching Hospitals NHS Trust',
+  },
+  questionnaire: {
+    id: '4789c2b3-7e37-4dd7-9642-0d456ae2f2bd',
+    url: null,
+    version: '1',
+    title: 'Discharge Destination',
+    status: QuestionnairePublicationStatus.Active,
+    metadata: mockMetadata,
+    identifier: [
+      {
+        system: 'http://leedsth.nhs.uk/user/guid',
+        value: 'cfe6a9d7-f23d-4bb9-a28d-8a3895bee48a',
+      },
+    ],
+    item: [
+      {
+        linkId: '1',
+        text: 'Discharge',
+        type: QuestionnaireItemTypeCode.Group,
+        repeats: false,
+        item: [
+          {
+            linkId: '1.1',
+            text: 'Expected discharge destination',
+            type: QuestionnaireItemTypeCode.QuestionString,
+            item: null,
+          },
+          {
+            linkId: '1.2',
+            text:
+              'Is the patient still residing in hospital because a COVID-19 test or test result is still outstanding?',
+            type: QuestionnaireItemTypeCode.QuestionBoolean,
+            item: null,
+          },
+        ],
+      },
+      {
+        linkId: '2',
+        text: 'External Transfer',
+        repeats: false,
+        type: QuestionnaireItemTypeCode.Group,
+        item: [
+          {
+            linkId: '2.1',
+            text: 'Hospital',
+            type: QuestionnaireItemTypeCode.QuestionString,
+            item: null,
+          },
+          {
+            linkId: '2.2',
+            text: 'Other Hospital',
+            type: QuestionnaireItemTypeCode.QuestionString,
+            item: null,
+          },
+          {
+            linkId: '2.3',
+            text: 'Additional Details',
+            type: QuestionnaireItemTypeCode.QuestionString,
+            item: null,
+          },
+        ],
+      },
+      {
+        linkId: '3',
+        text: 'Discharge Address',
+        type: QuestionnaireItemTypeCode.Group,
+        repeats: false,
+        item: [
+          {
+            linkId: '3.1',
+            text: 'Address',
+            type: QuestionnaireItemTypeCode.QuestionString,
+            item: null,
+          },
+          {
+            linkId: '3.2',
+            text: 'Postcode',
+            type: QuestionnaireItemTypeCode.QuestionString,
+            item: null,
+          },
+          {
+            linkId: '3.3',
+            text: 'Telephone Number',
+            type: QuestionnaireItemTypeCode.QuestionString,
+            item: null,
+          },
+        ],
+      },
+    ],
+  },
+  item: [
+    {
+      linkId: '2',
+      text: 'External Transfer',
+      answer: null,
+      item: [
+        {
+          linkId: '2.1',
+          text: null,
+          answer: [
+            {
+              valueString: 'Dewsbury District Hospital',
+              valueBoolean: null,
+              valueDateTime: null,
+            },
+          ],
+          item: [],
+        },
+        {
+          linkId: '2.3',
+          text: null,
+          answer: [],
+          item: [],
+        },
+      ],
+    },
+    {
+      linkId: '3',
+      text: 'Discharge Address',
+      answer: null,
+      item: [
+        {
+          linkId: '3.1',
+          text: null,
+          answer: [],
+          item: [],
+        },
+        {
+          linkId: '3.2',
+          text: null,
+          answer: [],
+          item: [],
+        },
+        {
+          linkId: '3.3',
+          text: null,
+          answer: [],
+          item: [],
+        },
+      ],
+    },
+  ],
+  metadata: mockMetadata,
+}

--- a/packages/storybook/src/clinical/organisms/questionnaire/questionnaire.stories.tsx
+++ b/packages/storybook/src/clinical/organisms/questionnaire/questionnaire.stories.tsx
@@ -21,6 +21,7 @@ import {
   NestedDischargeExample,
   DischargeClinicalSummaryExampleData,
   MissingAnswersExampleData,
+  DischargeDestinationExampleData,
 } from './questionnaire.fixtures'
 import { useDetailViewType } from '../hooks/useDetailViewTypeHook'
 
@@ -204,5 +205,24 @@ export const DischargeClinicalSummaryExample: Story = () => (
     </Card.Body>
   </Card>
 )
+
+export const DischargeDestinationExample: Story = () => {
+  const { viewType, toggle } = useDetailViewType()
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title>Questionnaire</Card.Title>{' '}
+        <Button
+          type="button"
+          value={viewType === DetailViewType.Expanded ? 'View compacted' : 'View expanded'}
+          onClick={toggle}
+        />
+      </Card.Header>
+      <Card.Body>
+        <Questionnaire questionnaire={DischargeDestinationExampleData} viewType={viewType} />
+      </Card.Body>
+    </Card>
+  )
+}
 
 export default { title: 'Clinical/Organisms/Questionnaire' }

--- a/packages/storybook/src/clinical/organisms/questionnaire/questionnaire.stories.tsx
+++ b/packages/storybook/src/clinical/organisms/questionnaire/questionnaire.stories.tsx
@@ -101,16 +101,25 @@ export const GroupedQuestions: Story = () => (
   </Card>
 )
 
-export const NoAnswer: Story = () => (
-  <Card>
-    <Card.Header>
-      <Card.Title>Questionnaire</Card.Title>
-    </Card.Header>
-    <Card.Body>
-      <Questionnaire questionnaire={NoAnswerData} />
-    </Card.Body>
-  </Card>
-)
+export const NoAnswer: Story = () => {
+  const { viewType, toggle } = useDetailViewType()
+
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title>Questionnaire</Card.Title>{' '}
+        <Button
+          type="button"
+          value={viewType === DetailViewType.Expanded ? 'View compacted' : 'View expanded'}
+          onClick={toggle}
+        />
+      </Card.Header>
+      <Card.Body>
+        <Questionnaire questionnaire={NoAnswerData} viewType={viewType} />
+      </Card.Body>
+    </Card>
+  )
+}
 
 export const RepeatingGroups: Story = () => (
   <Card>

--- a/packages/storybook/src/clinical/organisms/questionnaire/questionnaire.test.tsx
+++ b/packages/storybook/src/clinical/organisms/questionnaire/questionnaire.test.tsx
@@ -1,0 +1,105 @@
+import Questionnaire from '@ltht-react/questionnaire'
+import { DetailViewType, QuestionnaireResponse } from '@ltht-react/types'
+import { render, screen } from '@testing-library/react'
+import {
+  BooleanFieldData,
+  ComposedExampleData as NestedQuestionnaireData,
+  NoAnswerData,
+} from './questionnaire.fixtures'
+
+describe('Questionnaire', () => {
+  it('should render a question', async () => {
+    render(<Questionnaire questionnaire={BooleanFieldData} />)
+
+    await screen.findByText('Do you have allergies?')
+    screen.getByText('Yes')
+  })
+
+  it('should show question groups', async () => {
+    render(<Questionnaire questionnaire={NestedQuestionnaireData} />)
+
+    await screen.findByText('Do you have allergies?')
+    screen.getByText('Yes')
+
+    screen.getByText('General questions')
+
+    screen.getByText('What is your gender?')
+    screen.getByText(/Male/)
+  })
+
+  describe('compact view', () => {
+    it("should not show a question if it doesn't have an answer", async () => {
+      const data: QuestionnaireResponse = {
+        ...BooleanFieldData,
+        item: [
+          {
+            linkId: '1',
+            text: null,
+            answer: [],
+            item: null,
+          },
+        ],
+      }
+
+      render(
+        <>
+          <span>Render check</span>
+          <Questionnaire questionnaire={data} viewType={DetailViewType.Compact} />
+        </>
+      )
+
+      await screen.findByText('Render check')
+      expect(screen.queryByText('Do you have allergies?')).toBeNull()
+    })
+
+    it('should not show a group header when the children do not have answers', async () => {
+      render(
+        <>
+          <span>Render check</span>
+          <Questionnaire questionnaire={NoAnswerData} viewType={DetailViewType.Compact} />
+        </>
+      )
+
+      await screen.findByText('Render check')
+      expect(screen.queryByText('General questions')).toBeNull()
+    })
+  })
+
+  describe('expanded view', () => {
+    it('should show a question without an answer', async () => {
+      const data: QuestionnaireResponse = {
+        ...BooleanFieldData,
+        item: [
+          {
+            linkId: '1',
+            text: null,
+            answer: [],
+            item: null,
+          },
+        ],
+      }
+
+      render(
+        <>
+          <span>Render check</span>
+          <Questionnaire questionnaire={data} viewType={DetailViewType.Expanded} />
+        </>
+      )
+
+      await screen.findByText('Render check')
+      screen.getByText('Do you have allergies?')
+    })
+
+    it('should show a group header when the children do not have answers', async () => {
+      render(
+        <>
+          <span>Render check</span>
+          <Questionnaire questionnaire={NoAnswerData} viewType={DetailViewType.Expanded} />
+        </>
+      )
+
+      await screen.findByText('Render check')
+      screen.getByText('General questions')
+    })
+  })
+})


### PR DESCRIPTION
When rendering a questionnaire with question groups inside, we should not render the group title if all of it's children don't have answers.

In compact view currently, if a question group contains empty answers (i.e. the structure for the group's answers exist, but all of them are empty), we show the group title, but non of the group answer titles.

Easiest to see in story book on the [Discharge Destination story](http://localhost:9009/?path=/story/clinical-organisms-questionnaire--discharge-destination-example)