### PR TITLE
Update styles, fix IE 11, add title

### DIFF
--- a/components/styled/input/src/atoms/toggle.tsx
+++ b/components/styled/input/src/atoms/toggle.tsx
@@ -13,33 +13,38 @@ const StyledInput = styled.input`
   cursor: pointer;
   height: 1rem;
   width: 2rem;
-  background: linear-gradient(to left, rgba(0, 0, 0, 0) 50%, black 50%) right;
-  background-size: 200% 100%;
+  background: white;
   transition: all linear 0.1s;
 
   &::before {
     align-self: baseline;
-    background: white;
-    border: 1px solid black;
-    border-radius: 1rem;
+    background: black;
+    outline: 1px solid black;
+    border-radius: 0.4rem;
     content: '';
     display: block;
-    height: 1rem;
-    left: 0;
+    height: 0.6rem;
+    width: 0.6rem;
+    top: 0.25rem;
+    left: 0.22rem;
     margin-top: -2px;
     margin-left: -1px;
     position: relative;
-    top: 0;
-    width: 1rem;
-    transition: left linear 0.1s;
+    transition: left linear 0.1s, background linear 0.1s;
   }
 
   &:checked {
-    background-position: left;
+    background: black;
+
+    // Style overrides for IE 11 (fallback to normal checkbox)
+    // Only IE 10 & 11 use these media queries
+    @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
+      background: none;
+    }
   }
 
   &:checked::before {
-    left: 1rem;
+    left: 1.25rem;
     background: white;
   }
 `
@@ -52,13 +57,14 @@ const ToggleInput: FC<ToggleInputProps> = ({ checked, onChange, disabled, ...res
       disabled={disabled}
       onChange={(e) => !disabled && onChange && onChange(e)}
       {...rest}
+      title={checked ? 'On' : 'Off'}
     />
   </StyledToggleWrapper>
 )
 
 interface ToggleInputProps extends HTMLAttributes<HTMLInputElement> {
   checked: boolean
-  disabled?: boolean
+  disabled?: boolean | undefined
 }
 
 export default ToggleInput

--- a/components/styled/input/src/atoms/toggle.tsx
+++ b/components/styled/input/src/atoms/toggle.tsx
@@ -64,7 +64,7 @@ const ToggleInput: FC<ToggleInputProps> = ({ checked, onChange, disabled, ...res
 
 interface ToggleInputProps extends HTMLAttributes<HTMLInputElement> {
   checked: boolean
-  disabled?: boolean | undefined
+  disabled?: boolean
 }
 
 export default ToggleInput

--- a/packages/storybook/src/ui/atoms/inputs/toggle.test.tsx
+++ b/packages/storybook/src/ui/atoms/inputs/toggle.test.tsx
@@ -21,8 +21,8 @@ const TestHarness: FC<ITestHarnessProps> = ({ disabled, checked }) => {
 }
 
 interface ITestHarnessProps {
-  disabled?: boolean | undefined
-  checked?: boolean | undefined
+  disabled?: boolean
+  checked?: boolean
 }
 
 describe('toggle input', () => {
@@ -62,6 +62,7 @@ describe('toggle input', () => {
   it('should set a title attribute of "On" when it is checked', async () => {
     render(<TestHarness checked />)
 
+    screen.debug()
     expect(await screen.findByLabelText('Click me')).toHaveAttribute('title', 'On')
   })
 

--- a/packages/storybook/src/ui/atoms/inputs/toggle.test.tsx
+++ b/packages/storybook/src/ui/atoms/inputs/toggle.test.tsx
@@ -2,10 +2,10 @@
 import { Toggle } from '@ltht-react/input'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { useState } from 'react'
+import { FC, useState } from 'react'
 
-const TestHarness = ({ disabled }: { disabled: boolean }) => {
-  const [toggle, setToggle] = useState<boolean>(false)
+const TestHarness: FC<ITestHarnessProps> = ({ disabled, checked }) => {
+  const [toggle, setToggle] = useState<boolean>(checked ?? false)
 
   return (
     <>
@@ -20,32 +20,54 @@ const TestHarness = ({ disabled }: { disabled: boolean }) => {
   )
 }
 
-describe('toggle input', () => {
-  it('should start with a default value', () => {
-    const { container } = render(<Toggle checked />)
+interface ITestHarnessProps {
+  disabled?: boolean | undefined
+  checked?: boolean | undefined
+}
 
-    expect(container.querySelector(':checked')).not.toBeNull()
+describe('toggle input', () => {
+  it('should start with a default value', async () => {
+    render(<TestHarness checked />)
+
+    expect(await screen.findByLabelText('Click me')).toBeChecked()
   })
 
   it('should change when clicked', async () => {
-    const { container } = render(<TestHarness disabled={false} />)
-
-    expect(container.querySelector(':checked')).toBeNull()
+    render(<TestHarness disabled={false} />)
 
     const label = await screen.findByText('Click me')
+    const input = await screen.findByLabelText('Click me')
+
+    expect(input).not.toBeDisabled()
+    expect(input).not.toBeChecked()
+
     userEvent.click(label)
 
-    expect(container.querySelector(':checked')).not.toBeNull()
+    expect(input).toBeChecked()
   })
 
   it('should not let you change value when disabled', async () => {
-    const { container } = render(<TestHarness disabled />)
-
-    expect(container.querySelector(':checked')).toBeNull()
+    render(<TestHarness disabled />)
 
     const label = await screen.findByText('Click me')
+    const input = await screen.findByLabelText('Click me')
+
+    expect(input).toBeDisabled()
+
     userEvent.click(label)
 
-    expect(container.querySelector(':checked')).toBeNull()
+    expect(input).not.toBeChecked()
+  })
+
+  it('should set a title attribute of "On" when it is checked', async () => {
+    render(<TestHarness checked />)
+
+    expect(await screen.findByLabelText('Click me')).toHaveAttribute('title', 'On')
+  })
+
+  it('should set a title attribute of "Off" when it is not checked', async () => {
+    render(<TestHarness checked={false} />)
+
+    expect(await screen.findByLabelText('Click me')).toHaveAttribute('title', 'Off')
   })
 })


### PR DESCRIPTION
- Makes to toggle dot a bit smaller
- First point necessitated a change to the background transition between checked states (now just fades)
- toggle dot changes colour with checked state
- Adds a title to the input that describes its current state (useful for desktop devices)
- Resets some CSS styles so that IE 11 will just render it as a standard checkbox input rather than the mess it did before
- Couple of new tests for the title attribute
- Refactored existing tests so as not to use react-test-library's `container` stuff