### PR TITLE
Correct extension type on ConditionMinimalInput

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ storybook-static
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# IntelliJ
+/.idea

--- a/packages/types/src/atoms/graphql-types.ts
+++ b/packages/types/src/atoms/graphql-types.ts
@@ -3053,7 +3053,7 @@ export type ConditionMinimalInput = {
   id: Scalars['String']
   code: CodeableConceptInput
   onset?: Maybe<ConditionOnsetMinimalInput>
-  extension?: Maybe<ExtensionInput>
+  extension?: Maybe<Array<ExtensionInput>>
   clinicalStatus?: Maybe<ConditionClinicalStatus>
   verificationStatus?: Maybe<ConditionVerificationStatus>
 }


### PR DESCRIPTION
The extension property on ConditionalMinimalInput should be an array of ExtensionInput.

Added an exclusion to the .gitignore file as I use Rider as an IDE and it wasn't ignoring the files generated by the application.