### PR TITLE
Replace husky which was accidentally removed in a rebase merge conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-jsx-a11y": "^6.6.0",
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "husky": "^7.0.0",
     "jest": "^26.6.3",
     "lerna": "^5.1.0",
     "lerna-update-wizard": "^1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11704,6 +11704,11 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
+husky@^7.0.0:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.4.tgz#242048245dc49c8fb1bf0cc7cfb98dd722531535"
+  integrity sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==
+
 hyphenate-style-name@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"


### PR DESCRIPTION
When rebasing that react-table branch onto main it seems Husky got removed from package.json, and this caused the build to fail after we merged that branch.

This adds it back in - and should hopefully fix the build

