### PR TITLE
Stop sending React prop attributes down to html attributes

### DIFF
--- a/components/styled/table/src/atoms/table.tsx
+++ b/components/styled/table/src/atoms/table.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react'
-import { useTable, TableCellProps, Column } from 'react-table'
+import { useTable, Column } from 'react-table'
 
 import CssBaseline from '@material-ui/core/CssBaseline'
 import MaUTable from '@material-ui/core/Table'
@@ -13,12 +13,6 @@ import { TRANSLUCENT_BRIGHT_BLUE_TABLE, TRANSLUCENT_GREY_TABLE } from '@ltht-rea
 
 const Container = styled.div`
   background-color: white;
-`
-
-const StyledTableCell: FC<CellProps> = styled(TableCell)`
-  text-align: center !important;
-  background-color: ${(props: CellProps) =>
-    props.cellIndex % 2 === 1 ? TRANSLUCENT_GREY_TABLE : TRANSLUCENT_BRIGHT_BLUE_TABLE};
 `
 
 const StyledTableHeader = styled.th`
@@ -71,9 +65,15 @@ const Table: FC<IProps> = ({ tableData }) => {
             return (
               <TableRow {...row.getRowProps()}>
                 {row.cells.map((cell, cellIdx) => (
-                  <StyledTableCell cellIndex={cellIdx} {...cell.getCellProps()}>
+                  <TableCell
+                    style={{
+                      background: cellIdx % 2 === 1 ? TRANSLUCENT_GREY_TABLE : TRANSLUCENT_BRIGHT_BLUE_TABLE,
+                      textAlign: 'center',
+                    }}
+                    {...cell.getCellProps()}
+                  >
                     {cell.render('Cell')}
-                  </StyledTableCell>
+                  </TableCell>
                 ))}
               </TableRow>
             )
@@ -82,10 +82,6 @@ const Table: FC<IProps> = ({ tableData }) => {
       </MaUTable>
     </Container>
   )
-}
-
-interface CellProps extends TableCellProps {
-  cellIndex: number
 }
 
 interface IProps {


### PR DESCRIPTION
The console error we were seeing was because of the way we were creating the styled component. 
We're using an odd mix of both Emotion and MaterialUI here, and the interaction between them meant that what looked like React props were being applied to the html object itself. This was causing an error, because our React props obviously aren't valid css attributes. 

I've re-factored to use native Material-UI styles - this may or may not be the best way, I actually think if we're going to use MUI then we should apply a theme and use makeSyles() / useStyles etc. But it fixes the error so will do for now!