### PR TITLE
Task/test questionnaire table separately from generic table

### DIFF
--- a/components/styled/table/src/molecules/questionnaire-table.tsx
+++ b/components/styled/table/src/molecules/questionnaire-table.tsx
@@ -9,7 +9,7 @@ import { EnsureMaybe, EnsureMaybeArray, partialDateTimeText } from '@ltht-react/
 import { FC } from 'react'
 import Table, { Cell, CellRow, Header, TableData } from '../atoms/table'
 
-const mapQuestionnaireObjectsToVerticalTableData = (
+export const mapQuestionnaireObjectsToVerticalTableData = (
   definitionItems: Array<QuestionnaireItem>,
   records: QuestionnaireResponse[]
 ): TableData => ({
@@ -115,7 +115,7 @@ const recursivelyMapResponseItemsToCells = (items: QuestionnaireResponseItem[]):
   return cells
 }
 
-const mapQuestionnaireObjectsToHorizontalTableData = (
+export const mapQuestionnaireObjectsToHorizontalTableData = (
   definitionItems: Array<QuestionnaireItem>,
   records: QuestionnaireResponse[]
 ): TableData => ({

--- a/packages/storybook/src/ui/organisms/table/questionnaire-table.mockdata.ts
+++ b/packages/storybook/src/ui/organisms/table/questionnaire-table.mockdata.ts
@@ -1,0 +1,264 @@
+import { TableData } from '@ltht-react/table/src/atoms/table'
+
+export const summaryDefinitionOneVerticalTableData: TableData = {
+  headers: [
+    {
+      accessor: 'property',
+      header: '',
+    },
+    {
+      accessor: '1',
+      header: '17-Feb-2022 17:23',
+    },
+    {
+      accessor: '2',
+      header: '12-Feb-2022 12:33',
+    },
+    {
+      accessor: '3',
+      header: '01-Jan-2022 16:02',
+    },
+  ],
+  rows: [
+    {
+      cells: [
+        {
+          key: 'property',
+          value: 'Score',
+        },
+        {
+          key: '1',
+          value: '5 NEWS',
+        },
+        {
+          key: '2',
+          value: '4 NEWS',
+        },
+        {
+          key: '3',
+          value: '15 NEWS',
+        },
+      ],
+    },
+    {
+      cells: [
+        {
+          key: 'property',
+          value: 'Intervention',
+        },
+        {
+          key: '1',
+          value: 'ICON',
+        },
+        {
+          key: '2',
+          value: '',
+        },
+        {
+          key: '3',
+          value: '',
+        },
+      ],
+    },
+    {
+      cells: [
+        {
+          key: 'property',
+          value: 'Partial Indication',
+        },
+        {
+          key: '1',
+          value: '',
+        },
+        {
+          key: '2',
+          value: '',
+        },
+        {
+          key: '3',
+          value: '',
+        },
+      ],
+    },
+    {
+      cells: [
+        {
+          key: 'property',
+          value: 'Standard Observations',
+        },
+        {
+          key: '1',
+          value: 'CHECKBOX',
+        },
+        {
+          key: '2',
+          value: 'CHECKBOX',
+        },
+        {
+          key: '3',
+          value: 'CHECKBOX',
+        },
+      ],
+    },
+  ],
+}
+
+export const summaryDefinitionOneHorizontalTableData: TableData = {
+  headers: [
+    {
+      accessor: 'date',
+      header: 'Record Date',
+    },
+    {
+      accessor: '1',
+      header: 'Score',
+      subheaders: undefined,
+    },
+    {
+      accessor: '2',
+      header: 'Intervention',
+      subheaders: undefined,
+    },
+    {
+      accessor: '3',
+      header: 'Partial Indication',
+      subheaders: undefined,
+    },
+    {
+      accessor: '',
+      header: 'Standard Observations',
+      subheaders: [
+        {
+          accessor: '',
+          header: 'RR (breaths/min)',
+          subheaders: [
+            {
+              accessor: '4aa',
+              header: 'RR Part 1 (breaths/min)',
+              subheaders: undefined,
+            },
+            {
+              accessor: '4ab',
+              header: 'RR Part 2 (breaths/min)',
+              subheaders: undefined,
+            },
+          ],
+        },
+        {
+          accessor: '4b',
+          header: 'O2 Sat (%)',
+          subheaders: undefined,
+        },
+        {
+          accessor: '4c',
+          header: 'Supp O2',
+          subheaders: undefined,
+        },
+        {
+          accessor: '4d',
+          header: 'Blood Pressure',
+          subheaders: undefined,
+        },
+        {
+          accessor: '4e',
+          header: 'Standing 1 Minute BP',
+          subheaders: undefined,
+        },
+        {
+          accessor: '4f',
+          header: 'Standing 3 Minute BP',
+          subheaders: undefined,
+        },
+        {
+          accessor: '4g',
+          header: 'HR (BPM)',
+          subheaders: undefined,
+        },
+        {
+          accessor: '4h',
+          header: 'Temp (°C)',
+          subheaders: undefined,
+        },
+        {
+          accessor: '4i',
+          header: 'Consciousness',
+          subheaders: undefined,
+        },
+        {
+          accessor: '4j',
+          header: 'Pain Score',
+          subheaders: undefined,
+        },
+        {
+          accessor: '4k',
+          header: 'Blood Glucose (mmol/L)',
+          subheaders: undefined,
+        },
+      ],
+    },
+  ],
+  rows: [
+    {
+      cells: [
+        { key: 'date', value: '17-Feb-2022 17:23' },
+        { key: '1', value: '5 NEWS' },
+        { key: '2', value: 'ICON' },
+        { key: '3', value: '' },
+        { key: '4a', value: '25' },
+        { key: '4aa', value: '25(1)' },
+        { key: '4ab', value: '25(2)' },
+        { key: '4b', value: '92 (Target 94-98 %)' },
+        { key: '4c', value: '' },
+        { key: '4d', value: '144 / 122' },
+        { key: '4e', value: '' },
+        { key: '4f', value: '' },
+        { key: '4g', value: '88' },
+        { key: '4h', value: '37' },
+        { key: '4i', value: 'Alert' },
+        { key: '4j', value: '' },
+        { key: '4k', value: '' },
+        { key: '4', value: 'CHECKBOX' },
+      ],
+    },
+    {
+      cells: [
+        { key: 'date', value: '12-Feb-2022 12:33' },
+        { key: '1', value: '4 NEWS' },
+        { key: '2', value: '' },
+        { key: '3', value: '' },
+        { key: '4.1', value: '12' },
+        { key: '4.2', value: '94 (Target 94-98 %)' },
+        { key: '4.3', value: '' },
+        { key: '4.4', value: '122 / 88' },
+        { key: '4.5', value: '' },
+        { key: '4.6', value: '' },
+        { key: '4.7', value: '188' },
+        { key: '4.8', value: '37' },
+        { key: '4.9', value: 'Alert' },
+        { key: '4.10', value: '' },
+        { key: '4.11', value: '' },
+        { key: '4', value: 'CHECKBOX' },
+      ],
+    },
+    {
+      cells: [
+        { key: 'date', value: '01-Jan-2022 16:02' },
+        { key: '1', value: '15 NEWS' },
+        { key: '2', value: '' },
+        { key: '3', value: '' },
+        { key: '4.1', value: '65' },
+        { key: '4.2', value: '65 (Target 94-98 %)' },
+        { key: '4.3', value: '' },
+        { key: '4.4', value: '65 / 6' },
+        { key: '4.5', value: '' },
+        { key: '4.6', value: '' },
+        { key: '4.7', value: '64' },
+        { key: '4.8', value: '35' },
+        { key: '4.9', value: 'New Confusion' },
+        { key: '4.10', value: '1 - Mild Pain' },
+        { key: '4.11', value: '' },
+        { key: '4', value: 'CHECKBOX' },
+      ],
+    },
+  ],
+}

--- a/packages/storybook/src/ui/organisms/table/questionnaire-table.test.tsx
+++ b/packages/storybook/src/ui/organisms/table/questionnaire-table.test.tsx
@@ -1,0 +1,60 @@
+import QuestionnaireTable, {
+  mapQuestionnaireObjectsToHorizontalTableData,
+  mapQuestionnaireObjectsToVerticalTableData,
+} from '@ltht-react/table/src/molecules/questionnaire-table'
+import { render, screen } from '@testing-library/react'
+import {
+  summaryDefinitionOneHorizontalTableData,
+  summaryDefinitionOneVerticalTableData,
+} from './questionnaire-table.mockdata'
+import { summaryDefinitionItems, summaryRecordsList } from './table.fixtures'
+
+describe('Questionnaire Table', () => {
+  it('Maps vertically as expected', () => {
+    const result = mapQuestionnaireObjectsToVerticalTableData(summaryDefinitionItems, summaryRecordsList)
+
+    expect(result).toEqual(summaryDefinitionOneVerticalTableData)
+  })
+
+  it('Maps horizontally as expected', () => {
+    const result = mapQuestionnaireObjectsToHorizontalTableData(summaryDefinitionItems, summaryRecordsList)
+
+    expect(result).toEqual(summaryDefinitionOneHorizontalTableData)
+  })
+
+  it('Renders Vertically', () => {
+    render(
+      <QuestionnaireTable
+        definitionItems={summaryDefinitionItems}
+        records={summaryRecordsList}
+        orientation={'VERTICAL'}
+      />
+    )
+
+    expect(screen.getByRole('table')).toBeVisible()
+
+    // Assert that dates are in the headers
+    expect(screen.getByRole('columnheader', { name: /17-Feb-2022 17:23/ })).toBeVisible()
+
+    // Assert that subheaders are ignored in Vertical Mode
+    expect(screen.queryByRole('columnheader', { name: /Partial Indication/ })).toBeNull()
+  })
+
+  it('Renders Vertically', () => {
+    render(
+      <QuestionnaireTable
+        definitionItems={summaryDefinitionItems}
+        records={summaryRecordsList}
+        orientation={'HORIZONTAL'}
+      />
+    )
+
+    expect(screen.getByRole('table')).toBeVisible()
+
+    // Assert that dates are in the headers
+    expect(screen.getByRole('columnheader', { name: /Record Date/ })).toBeVisible()
+
+    // Assert that subheaders are visible
+    expect(screen.getByRole('columnheader', { name: /Partial Indication/ })).toBeVisible()
+  })
+})

--- a/packages/storybook/src/ui/organisms/table/questionnaire-table.test.tsx
+++ b/packages/storybook/src/ui/organisms/table/questionnaire-table.test.tsx
@@ -27,7 +27,7 @@ describe('Questionnaire Table', () => {
       <QuestionnaireTable
         definitionItems={summaryDefinitionItems}
         records={summaryRecordsList}
-        orientation={'VERTICAL'}
+        orientation="VERTICAL"
       />
     )
 
@@ -45,7 +45,7 @@ describe('Questionnaire Table', () => {
       <QuestionnaireTable
         definitionItems={summaryDefinitionItems}
         records={summaryRecordsList}
-        orientation={'HORIZONTAL'}
+        orientation="HORIZONTAL"
       />
     )
 

--- a/packages/storybook/src/ui/organisms/table/table.fixtures.ts
+++ b/packages/storybook/src/ui/organisms/table/table.fixtures.ts
@@ -1,11 +1,107 @@
 import {
   PartialDateTimeKindCode,
   Questionnaire,
+  QuestionnaireItem,
   QuestionnaireItemTypeCode,
   QuestionnairePublicationStatus,
   QuestionnaireResponse,
   QuestionnaireResponseStatus,
 } from '@ltht-react/types'
+
+export const summaryDefinitionItems: QuestionnaireItem[] = [
+  {
+    text: 'Score',
+    type: QuestionnaireItemTypeCode.QuestionString,
+    linkId: '1',
+    item: null,
+  },
+  {
+    text: 'Intervention',
+    type: QuestionnaireItemTypeCode.QuestionString,
+    linkId: '2',
+    item: null,
+  },
+  {
+    text: 'Partial Indication',
+    type: QuestionnaireItemTypeCode.QuestionString,
+    linkId: '3',
+    item: null,
+  },
+  {
+    text: 'Standard Observations',
+    type: QuestionnaireItemTypeCode.Group,
+    linkId: '4',
+    item: [
+      {
+        text: 'RR (breaths/min)',
+        type: QuestionnaireItemTypeCode.Group,
+        linkId: '4a',
+        item: [
+          {
+            text: 'RR Part 1 (breaths/min)',
+            type: QuestionnaireItemTypeCode.QuestionString,
+            linkId: '4aa',
+          },
+          {
+            text: 'RR Part 2 (breaths/min)',
+            type: QuestionnaireItemTypeCode.QuestionString,
+            linkId: '4ab',
+          },
+        ],
+      },
+      {
+        text: 'O2 Sat (%)',
+        type: QuestionnaireItemTypeCode.QuestionString,
+        linkId: '4b',
+      },
+      {
+        text: 'Supp O2',
+        type: QuestionnaireItemTypeCode.QuestionString,
+        linkId: '4c',
+      },
+      {
+        text: 'Blood Pressure',
+        type: QuestionnaireItemTypeCode.QuestionString,
+        linkId: '4d',
+      },
+      {
+        text: 'Standing 1 Minute BP',
+        type: QuestionnaireItemTypeCode.QuestionString,
+        linkId: '4e',
+      },
+      {
+        text: 'Standing 3 Minute BP',
+        type: QuestionnaireItemTypeCode.QuestionString,
+        linkId: '4f',
+      },
+      {
+        text: 'HR (BPM)',
+        type: QuestionnaireItemTypeCode.QuestionString,
+        linkId: '4g',
+      },
+      {
+        text: 'Temp (°C)',
+        type: QuestionnaireItemTypeCode.QuestionString,
+        linkId: '4h',
+      },
+      {
+        text: 'Consciousness',
+        type: QuestionnaireItemTypeCode.QuestionString,
+        linkId: '4i',
+      },
+      {
+        text: 'Pain Score',
+        type: QuestionnaireItemTypeCode.QuestionString,
+        linkId: '4j',
+      },
+      {
+        text: 'Blood Glucose (mmol/L)',
+        type: QuestionnaireItemTypeCode.QuestionString,
+        linkId: '4k',
+      },
+    ],
+  },
+]
 
 export const summaryDefinition: Questionnaire = {
   extension: [
@@ -39,100 +135,7 @@ export const summaryDefinition: Questionnaire = {
   status: QuestionnairePublicationStatus.Active,
   id: '1',
   title: 'Observations',
-  item: [
-    {
-      text: 'Score',
-      type: QuestionnaireItemTypeCode.QuestionString,
-      linkId: '1',
-      item: null,
-    },
-    {
-      text: 'Intervention',
-      type: QuestionnaireItemTypeCode.QuestionString,
-      linkId: '2',
-      item: null,
-    },
-    {
-      text: 'Partial Indication',
-      type: QuestionnaireItemTypeCode.QuestionString,
-      linkId: '3',
-      item: null,
-    },
-    {
-      text: 'Standard Observations',
-      type: QuestionnaireItemTypeCode.Group,
-      linkId: '4',
-      item: [
-        {
-          text: 'RR (breaths/min)',
-          type: QuestionnaireItemTypeCode.Group,
-          linkId: '4a',
-          item: [
-            {
-              text: 'RR Part 1 (breaths/min)',
-              type: QuestionnaireItemTypeCode.QuestionString,
-              linkId: '4aa',
-            },
-            {
-              text: 'RR Part 2 (breaths/min)',
-              type: QuestionnaireItemTypeCode.QuestionString,
-              linkId: '4ab',
-            },
-          ],
-        },
-        {
-          text: 'O2 Sat (%)',
-          type: QuestionnaireItemTypeCode.QuestionString,
-          linkId: '4b',
-        },
-        {
-          text: 'Supp O2',
-          type: QuestionnaireItemTypeCode.QuestionString,
-          linkId: '4c',
-        },
-        {
-          text: 'Blood Pressure',
-          type: QuestionnaireItemTypeCode.QuestionString,
-          linkId: '4d',
-        },
-        {
-          text: 'Standing 1 Minute BP',
-          type: QuestionnaireItemTypeCode.QuestionString,
-          linkId: '4e',
-        },
-        {
-          text: 'Standing 3 Minute BP',
-          type: QuestionnaireItemTypeCode.QuestionString,
-          linkId: '4f',
-        },
-        {
-          text: 'HR (BPM)',
-          type: QuestionnaireItemTypeCode.QuestionString,
-          linkId: '4g',
-        },
-        {
-          text: 'Temp (°C)',
-          type: QuestionnaireItemTypeCode.QuestionString,
-          linkId: '4h',
-        },
-        {
-          text: 'Consciousness',
-          type: QuestionnaireItemTypeCode.QuestionString,
-          linkId: '4i',
-        },
-        {
-          text: 'Pain Score',
-          type: QuestionnaireItemTypeCode.QuestionString,
-          linkId: '4j',
-        },
-        {
-          text: 'Blood Glucose (mmol/L)',
-          type: QuestionnaireItemTypeCode.QuestionString,
-          linkId: '4k',
-        },
-      ],
-    },
-  ],
+  item: summaryDefinitionItems,
 }
 
 const summaryRecordOne: QuestionnaireResponse = {

--- a/packages/storybook/src/ui/organisms/table/table.test.tsx
+++ b/packages/storybook/src/ui/organisms/table/table.test.tsx
@@ -2,7 +2,6 @@ import { render, screen } from '@testing-library/react'
 import Table from '@ltht-react/table'
 import { QuestionnaireItem } from '@ltht-react/types'
 import { mockSummaryDefinition, mockSummaryRecordsList } from './table.mockdata'
-import { summaryDefinition, summaryRecordsList } from './table.fixtures'
 
 describe('Table', () => {
   it('Renders', () => {
@@ -28,7 +27,7 @@ describe('Table', () => {
   })
 
   it('Renders Horizontally', () => {
-    render(<Table definition={summaryDefinition} records={summaryRecordsList} orientation="HORIZONTAL" />)
+    render(<Table definition={mockSummaryDefinition} records={mockSummaryRecordsList} orientation="HORIZONTAL" />)
   })
 
   it('Renders horizontal table with multiple row headers. total 13 columns to be visible', () => {


### PR DESCRIPTION
Adds some additional tests specifically for the QuestionnaireTable component (separately from the generic Table component)

Depends upon the[ re-factor PR](https://github.com/ltht-epr/ltht-react/pull/145) for certain types and method changes, so is effectively WIP until that's merged though should only need a cheeky rebase afterwards.