### PR TITLE
Task/use memo and add sorting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,7 @@ module.exports = {
       jsx: true,
     },
   },
-  ignorePatterns: ['packages/types/src/atoms/graphql-types.ts'],
+  ignorePatterns: ['packages/types/src/atoms/graphql-types.ts', '**/*.d.ts'],
   rules: {
     'jsx-a11y/no-static-element-interactions': [
       'error',

--- a/components/styled/table/src/atoms/table.tsx
+++ b/components/styled/table/src/atoms/table.tsx
@@ -75,7 +75,6 @@ export default function Table<TColumn, TRow>({
               {headerGroup.headers.map((column) => (
                 <StyledTableHeader {...column.getHeaderProps(column.getSortByToggleProps())}>
                   {column.render('Header')}
-                  {/* Add a sort direction indicator */}
                   <span>{column.isSorted ? (column.isSortedDesc ? ' 🔽' : ' 🔼') : ''}</span>
                 </StyledTableHeader>
               ))}

--- a/components/styled/table/src/atoms/table.tsx
+++ b/components/styled/table/src/atoms/table.tsx
@@ -21,9 +21,11 @@ const generateColumnsFromHeadersRecursively = (headers?: Header[]): Column<Recor
   (headers ?? []).map((header) => {
     return {
       Header: header.header,
-      accessor: header.accessor,
+      accessor: !!header.subheaders ? '' : header.accessor,
       columns: !!header.subheaders ? generateColumnsFromHeadersRecursively(header.subheaders) : undefined,
       sortType: 'basic',
+      // TODO: Figure out why sorting headers with subheaders causes an error and fix
+      disableSortBy: !!header.subheaders,
     }
   })
 

--- a/components/styled/table/src/atoms/table.tsx
+++ b/components/styled/table/src/atoms/table.tsx
@@ -1,4 +1,4 @@
-import { useTable, Column, useSortBy } from 'react-table'
+import { useTable, Column, useSortBy, HeaderGroup } from 'react-table'
 import CssBaseline from '@material-ui/core/CssBaseline'
 import MaUTable from '@material-ui/core/Table'
 import TableBody from '@material-ui/core/TableBody'
@@ -18,16 +18,14 @@ const StyledTableHeader = styled.th`
 `
 
 const generateColumnsFromHeadersRecursively = (headers?: Header[]): Column<Record<string, string>>[] =>
-  (headers ?? []).map((header) => {
-    return {
-      Header: header.header,
-      accessor: !!header.subheaders ? '' : header.accessor,
-      columns: !!header.subheaders ? generateColumnsFromHeadersRecursively(header.subheaders) : undefined,
-      sortType: 'basic',
-      // TODO: Figure out why sorting headers with subheaders causes an error and fix
-      disableSortBy: !!header.subheaders,
-    }
-  })
+  (headers ?? []).map((header) => ({
+    Header: header.header,
+    accessor: header.subheaders ? '' : header.accessor,
+    columns: header.subheaders ? generateColumnsFromHeadersRecursively(header.subheaders) : undefined,
+    sortType: 'basic',
+    // TODO: Figure out why sorting headers with subheaders causes an error and fix
+    disableSortBy: !!header.subheaders,
+  }))
 
 const generateRowsFromCellRows = (cellRows: CellRow[]): Record<string, string>[] =>
   cellRows.map((cellRow) => {
@@ -67,6 +65,13 @@ export default function Table<TColumn, TRow>({
     useSortBy
   )
 
+  const sortIcon = (column: HeaderGroup<Record<string, string>>) => {
+    if (column.isSorted) {
+      return <span>{column.isSortedDesc ? ' 🔽' : ' 🔼'}</span>
+    }
+    return ''
+  }
+
   return (
     <Container>
       <CssBaseline />
@@ -77,7 +82,7 @@ export default function Table<TColumn, TRow>({
               {headerGroup.headers.map((column) => (
                 <StyledTableHeader {...column.getHeaderProps(column.getSortByToggleProps())}>
                   {column.render('Header')}
-                  <span>{column.isSorted ? (column.isSortedDesc ? ' 🔽' : ' 🔼') : ''}</span>
+                  {sortIcon(column)}
                 </StyledTableHeader>
               ))}
             </tr>

--- a/components/styled/table/src/molecules/questionnaire-table.tsx
+++ b/components/styled/table/src/molecules/questionnaire-table.tsx
@@ -6,7 +6,7 @@ import {
   QuestionnaireResponseItemAnswer,
 } from '@ltht-react/types'
 import { EnsureMaybe, EnsureMaybeArray, partialDateTimeText } from '@ltht-react/utils'
-import { FC } from 'react'
+import { FC, useMemo } from 'react'
 import Table, { Cell, CellRow, Header, TableData } from '../atoms/table'
 
 export const mapQuestionnaireObjectsToVerticalTableData = (
@@ -130,10 +130,12 @@ export const mapQuestionnaireObjectsToHorizontalTableData = (
 })
 
 const QuestionnaireTable: FC<IProps> = ({ definitionItems, records, orientation }) => {
-  const tableData =
-    orientation === 'VERTICAL'
-      ? mapQuestionnaireObjectsToVerticalTableData(definitionItems, records)
-      : mapQuestionnaireObjectsToHorizontalTableData(definitionItems, records)
+  const tableData = useMemo(() => {
+    if (orientation === 'VERTICAL') {
+      return mapQuestionnaireObjectsToVerticalTableData(definitionItems, records)
+    }
+    return mapQuestionnaireObjectsToHorizontalTableData(definitionItems, records)
+  }, [orientation, definitionItems, records])
 
   return <Table tableData={tableData} />
 }

--- a/components/styled/table/src/react-table-config.d.ts
+++ b/components/styled/table/src/react-table-config.d.ts
@@ -1,0 +1,118 @@
+import {
+  UseColumnOrderInstanceProps,
+  UseColumnOrderState,
+  UseExpandedHooks,
+  UseExpandedInstanceProps,
+  UseExpandedOptions,
+  UseExpandedRowProps,
+  UseExpandedState,
+  UseFiltersColumnOptions,
+  UseFiltersColumnProps,
+  UseFiltersInstanceProps,
+  UseFiltersOptions,
+  UseFiltersState,
+  UseGlobalFiltersColumnOptions,
+  UseGlobalFiltersInstanceProps,
+  UseGlobalFiltersOptions,
+  UseGlobalFiltersState,
+  UseGroupByCellProps,
+  UseGroupByColumnOptions,
+  UseGroupByColumnProps,
+  UseGroupByHooks,
+  UseGroupByInstanceProps,
+  UseGroupByOptions,
+  UseGroupByRowProps,
+  UseGroupByState,
+  UsePaginationInstanceProps,
+  UsePaginationOptions,
+  UsePaginationState,
+  UseResizeColumnsColumnOptions,
+  UseResizeColumnsColumnProps,
+  UseResizeColumnsOptions,
+  UseResizeColumnsState,
+  UseRowSelectHooks,
+  UseRowSelectInstanceProps,
+  UseRowSelectOptions,
+  UseRowSelectRowProps,
+  UseRowSelectState,
+  UseRowStateCellProps,
+  UseRowStateInstanceProps,
+  UseRowStateOptions,
+  UseRowStateRowProps,
+  UseRowStateState,
+  UseSortByColumnOptions,
+  UseSortByColumnProps,
+  UseSortByHooks,
+  UseSortByInstanceProps,
+  UseSortByOptions,
+  UseSortByState,
+} from 'react-table'
+
+declare module 'react-table' {
+  // take this file as-is, or comment out the sections that don't apply to your plugin configuration
+
+  export interface TableOptions<D extends object>
+    extends UseExpandedOptions<D>,
+      UseFiltersOptions<D>,
+      UseGlobalFiltersOptions<D>,
+      UseGroupByOptions<D>,
+      UsePaginationOptions<D>,
+      UseResizeColumnsOptions<D>,
+      UseRowSelectOptions<D>,
+      UseRowStateOptions<D>,
+      UseSortByOptions<D>,
+      // note that having Record here allows you to add anything to the options, this matches the spirit of the
+      // underlying js library, but might be cleaner if it's replaced by a more specific type that matches your
+      // feature set, this is a safe default.
+      Record<string, any> {}
+
+  export interface Hooks<D extends object = {}>
+    extends UseExpandedHooks<D>,
+      UseGroupByHooks<D>,
+      UseRowSelectHooks<D>,
+      UseSortByHooks<D> {}
+
+  export interface TableInstance<D extends object = {}>
+    extends UseColumnOrderInstanceProps<D>,
+      UseExpandedInstanceProps<D>,
+      UseFiltersInstanceProps<D>,
+      UseGlobalFiltersInstanceProps<D>,
+      UseGroupByInstanceProps<D>,
+      UsePaginationInstanceProps<D>,
+      UseRowSelectInstanceProps<D>,
+      UseRowStateInstanceProps<D>,
+      UseSortByInstanceProps<D> {}
+
+  export interface TableState<D extends object = {}>
+    extends UseColumnOrderState<D>,
+      UseExpandedState<D>,
+      UseFiltersState<D>,
+      UseGlobalFiltersState<D>,
+      UseGroupByState<D>,
+      UsePaginationState<D>,
+      UseResizeColumnsState<D>,
+      UseRowSelectState<D>,
+      UseRowStateState<D>,
+      UseSortByState<D> {}
+
+  export interface ColumnInterface<D extends object = {}>
+    extends UseFiltersColumnOptions<D>,
+      UseGlobalFiltersColumnOptions<D>,
+      UseGroupByColumnOptions<D>,
+      UseResizeColumnsColumnOptions<D>,
+      UseSortByColumnOptions<D> {}
+
+  export interface ColumnInstance<D extends object = {}>
+    extends UseFiltersColumnProps<D>,
+      UseGroupByColumnProps<D>,
+      UseResizeColumnsColumnProps<D>,
+      UseSortByColumnProps<D> {}
+
+  export interface Cell<D extends object = {}, V = any> extends UseGroupByCellProps<D>, UseRowStateCellProps<D> {}
+
+  export interface Row<D extends object = {}>
+    extends UseExpandedRowProps<D>,
+      UseGroupByRowProps<D>,
+      UseRowSelectRowProps<D>,
+      UseRowStateRowProps<D> {}
+}

--- a/packages/storybook/src/ui/organisms/table/questionnaire-table.test.tsx
+++ b/packages/storybook/src/ui/organisms/table/questionnaire-table.test.tsx
@@ -3,6 +3,7 @@ import QuestionnaireTable, {
   mapQuestionnaireObjectsToVerticalTableData,
 } from '@ltht-react/table/src/molecules/questionnaire-table'
 import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import {
   summaryDefinitionOneHorizontalTableData,
   summaryDefinitionOneVerticalTableData,
@@ -59,5 +60,25 @@ describe('Questionnaire Table', () => {
     expect(
       screen.getAllByRole('columnheader').some((header) => within(header).queryByText('Partial Indication') !== null)
     ).toBe(true)
+  })
+
+  it('Sorts the table when headers are clicked', () => {
+    render(
+      <QuestionnaireTable
+        definitionItems={summaryDefinitionItems}
+        records={summaryRecordsList}
+        orientation="VERTICAL"
+      />
+    )
+
+    const getTopLeftDataCell = () => {
+      return within(screen.getAllByRole('row')[1]).getAllByRole('cell')[0]
+    }
+
+    expect(getTopLeftDataCell()).toHaveTextContent('Score')
+
+    userEvent.click(screen.getByText('17-Feb-2022 17:23'))
+
+    expect(getTopLeftDataCell()).toHaveTextContent('Partial Indication')
   })
 })

--- a/packages/storybook/src/ui/organisms/table/questionnaire-table.test.tsx
+++ b/packages/storybook/src/ui/organisms/table/questionnaire-table.test.tsx
@@ -2,7 +2,7 @@ import QuestionnaireTable, {
   mapQuestionnaireObjectsToHorizontalTableData,
   mapQuestionnaireObjectsToVerticalTableData,
 } from '@ltht-react/table/src/molecules/questionnaire-table'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import {
   summaryDefinitionOneHorizontalTableData,
   summaryDefinitionOneVerticalTableData,
@@ -34,13 +34,13 @@ describe('Questionnaire Table', () => {
     expect(screen.getByRole('table')).toBeVisible()
 
     // Assert that dates are in the headers
-    expect(screen.getByRole('columnheader', { name: /17-Feb-2022 17:23/ })).toBeVisible()
+    expect(within(screen.getAllByRole('columnheader')[1]).getByText('17-Feb-2022 17:23')).toBeVisible()
 
     // Assert that subheaders are ignored in Vertical Mode
     expect(screen.queryByRole('columnheader', { name: /Partial Indication/ })).toBeNull()
   })
 
-  it('Renders Vertically', () => {
+  it('Renders Horizontally', () => {
     render(
       <QuestionnaireTable
         definitionItems={summaryDefinitionItems}
@@ -52,9 +52,12 @@ describe('Questionnaire Table', () => {
     expect(screen.getByRole('table')).toBeVisible()
 
     // Assert that dates are in the headers
-    expect(screen.getByRole('columnheader', { name: /Record Date/ })).toBeVisible()
+    const headers = screen.getAllByRole('columnheader')
+    expect(headers.some((header) => within(header).queryByText('Record Date') !== null)).toBe(true)
 
     // Assert that subheaders are visible
-    expect(screen.getByRole('columnheader', { name: /Partial Indication/ })).toBeVisible()
+    expect(
+      screen.getAllByRole('columnheader').some((header) => within(header).queryByText('Partial Indication') !== null)
+    ).toBe(true)
   })
 })

--- a/packages/storybook/src/ui/organisms/table/questionnaire-table.test.tsx
+++ b/packages/storybook/src/ui/organisms/table/questionnaire-table.test.tsx
@@ -71,9 +71,7 @@ describe('Questionnaire Table', () => {
       />
     )
 
-    const getTopLeftDataCell = () => {
-      return within(screen.getAllByRole('row')[1]).getAllByRole('cell')[0]
-    }
+    const getTopLeftDataCell = () => within(screen.getAllByRole('row')[1]).getAllByRole('cell')[0]
 
     expect(getTopLeftDataCell()).toHaveTextContent('Score')
 
@@ -91,9 +89,7 @@ describe('Questionnaire Table', () => {
       />
     )
 
-    const getTopLeftDataCell = () => {
-      return within(screen.getAllByRole('row')[3]).getAllByRole('cell')[0]
-    }
+    const getTopLeftDataCell = () => within(screen.getAllByRole('row')[3]).getAllByRole('cell')[0]
 
     expect(getTopLeftDataCell()).toHaveTextContent('17-Feb-2022 17:23')
 
@@ -111,9 +107,7 @@ describe('Questionnaire Table', () => {
       />
     )
 
-    const getTopLeftDataCell = () => {
-      return within(screen.getAllByRole('row')[3]).getAllByRole('cell')[0]
-    }
+    const getTopLeftDataCell = () => within(screen.getAllByRole('row')[3]).getAllByRole('cell')[0]
 
     expect(getTopLeftDataCell()).toHaveTextContent('17-Feb-2022 17:23')
 

--- a/packages/storybook/src/ui/organisms/table/questionnaire-table.test.tsx
+++ b/packages/storybook/src/ui/organisms/table/questionnaire-table.test.tsx
@@ -81,4 +81,44 @@ describe('Questionnaire Table', () => {
 
     expect(getTopLeftDataCell()).toHaveTextContent('Partial Indication')
   })
+
+  it('Sorts the table if the lowest level of subheaders are clicked in horizontal mode', () => {
+    render(
+      <QuestionnaireTable
+        definitionItems={summaryDefinitionItems}
+        records={summaryRecordsList}
+        orientation="HORIZONTAL"
+      />
+    )
+
+    const getTopLeftDataCell = () => {
+      return within(screen.getAllByRole('row')[3]).getAllByRole('cell')[0]
+    }
+
+    expect(getTopLeftDataCell()).toHaveTextContent('17-Feb-2022 17:23')
+
+    userEvent.click(screen.getByText('Record Date'))
+
+    expect(getTopLeftDataCell()).toHaveTextContent('01-Jan-2022 16:02')
+  })
+
+  it('Does not try to sort the table when a header grouping is clicked', () => {
+    render(
+      <QuestionnaireTable
+        definitionItems={summaryDefinitionItems}
+        records={summaryRecordsList}
+        orientation="HORIZONTAL"
+      />
+    )
+
+    const getTopLeftDataCell = () => {
+      return within(screen.getAllByRole('row')[3]).getAllByRole('cell')[0]
+    }
+
+    expect(getTopLeftDataCell()).toHaveTextContent('17-Feb-2022 17:23')
+
+    userEvent.click(screen.getByText('RR (breaths/min)'))
+
+    expect(getTopLeftDataCell()).toHaveTextContent('17-Feb-2022 17:23')
+  })
 })


### PR DESCRIPTION
Adds the sorting functionality to vertical tables and for the lowest level of headers on horizontal tables. 
Sorting header groups has proven more trouble than it's worth for now so that will have to be future work. 