### PR TITLE
Let EnsureMaybeArray cater for the `Foo[] | undefined` type

### DIFF
--- a/components/styled/table/src/organisms/questionnaire-table-methods.tsx
+++ b/components/styled/table/src/organisms/questionnaire-table-methods.tsx
@@ -165,9 +165,7 @@ const mapQuestionnaireResponsesIntoCellRow = (records: QuestionnaireResponse[]):
           const answer = EnsureMaybe<QuestionnaireResponseItemAnswer>(item?.answer?.find((answer) => !!answer))
 
           if (answer.item) {
-            const items = recursivelyMapResponseItemsToCells(
-              EnsureMaybeArray<QuestionnaireResponseItem>(answer.item ?? [])
-            )
+            const items = recursivelyMapResponseItemsToCells(EnsureMaybeArray<QuestionnaireResponseItem>(answer.item))
 
             items.forEach((x) => {
               cellArray.push({

--- a/packages/utils/src/atoms/ensure-maybe.ts
+++ b/packages/utils/src/atoms/ensure-maybe.ts
@@ -6,13 +6,11 @@ export const EnsureMaybeArray = <Type>(maybeArray: Maybe<Type>[] | undefined): T
   }
 
   const definitelyArray: Type[] = []
-  if (maybeArray !== undefined) {
-    maybeArray.forEach((item) => {
-      if (item !== null) {
-        definitelyArray.push(item)
-      }
-    })
-  }
+  maybeArray.forEach((item) => {
+    if (item !== null) {
+      definitelyArray.push(item)
+    }
+  })
 
   return definitelyArray
 }

--- a/packages/utils/src/atoms/ensure-maybe.ts
+++ b/packages/utils/src/atoms/ensure-maybe.ts
@@ -1,6 +1,10 @@
 import { Maybe } from '@ltht-react/types'
 
-export const EnsureMaybeArray = <Type>(maybeArray: Maybe<Type>[]): Type[] => {
+export const EnsureMaybeArray = <Type>(maybeArray: Maybe<Type>[] | undefined): Type[] => {
+  if (!maybeArray) {
+    return []
+  }
+
   const definitelyArray: Type[] = []
   if (maybeArray !== undefined) {
     maybeArray.forEach((item) => {


### PR DESCRIPTION
Makes EnsureMaybeArray that -bit- more useful

... have I mentioned how much I hate the `<Maybe>` object?