### PR TITLE
Refactor checkbox component

### DIFF
--- a/components/styled/input/src/atoms/checkbox.tsx
+++ b/components/styled/input/src/atoms/checkbox.tsx
@@ -1,22 +1,45 @@
-import { ChangeEvent, FC, HTMLAttributes } from 'react'
+import { ChangeEvent, FC, HTMLAttributes, InputHTMLAttributes } from 'react'
 import styled from '@emotion/styled'
-import { css, SerializedStyles } from '@emotion/react'
-import { INPUT_COLOURS } from '@ltht-react/styles'
+import { BADGE_COLOURS } from '@ltht-react/styles'
 
-const StyledCheckbox = styled.div<StyledCheckboxProps>`
-  padding-left: 1.25rem;
-
-  ${({ checked }): ConditionalStyles =>
-    checked &&
-    css`
-      background-color: ${INPUT_COLOURS.RADIO_SELECTED};
-    `}
+const StyledCheckbox = styled.div<InputHTMLAttributes<HTMLInputElement>>`
+  display: flex;
+  align-items: center;
 `
 
 const StyledInput = styled.input`
-  position: absolute;
-  margin-top: 0.15rem;
-  margin-left: -1.25rem;
+  appearance: none;
+  height: 1.2em;
+  margin: 0;
+  margin-right: 0.5em;
+  position: relative;
+  width: 1em;
+
+  &:before {
+    border: solid 1px grey;
+    border-radius: 3px;
+    content: '';
+    display: inline-block;
+    height: 1em;
+    width: 1em;
+  }
+
+  &:checked:before {
+    background-color: ${BADGE_COLOURS.PRIMARY};
+    content: '';
+    color: white;
+  }
+
+  &:checked:after {
+    color: white;
+    content: '\\2714';
+    font-size: 0.8em;
+    height: 1em;
+    left: 0.25em;
+    position: absolute;
+    top: 0;
+    width: 1em;
+  }
 `
 
 const StyledLabel = styled.label`
@@ -24,24 +47,18 @@ const StyledLabel = styled.label`
   margin-bottom: 0;
 `
 
-const Checkbox: FC<Props> = ({ id, value, checked = false, label, changeHandler, ...rest }) => (
-  <StyledCheckbox checked={checked} {...rest}>
-    <StyledInput id={id} onChange={changeHandler} value={value} type="radio" checked={checked} />
-    <StyledLabel htmlFor={id}>{label}</StyledLabel>
+const Checkbox: FC<Props> = ({ id, checked = false, onChange, children, ...rest }) => (
+  <StyledCheckbox {...rest}>
+    <StyledInput id={id} onChange={onChange} type="checkbox" checked={checked} />
+    <StyledLabel htmlFor={id}>{children}</StyledLabel>
   </StyledCheckbox>
 )
 
-type ConditionalStyles = SerializedStyles | false
-interface StyledCheckboxProps {
-  checked: boolean
-}
-
 interface Props extends HTMLAttributes<HTMLDivElement> {
   id: string
-  value: string
-  checked?: boolean
-  label: string
-  changeHandler(e: ChangeEvent<HTMLInputElement>): void
+  checked: boolean
+  children: React.ReactNode
+  onChange(e: ChangeEvent<HTMLInputElement>): void
 }
 
 export default Checkbox

--- a/components/styled/input/src/atoms/checkbox.tsx
+++ b/components/styled/input/src/atoms/checkbox.tsx
@@ -49,7 +49,7 @@ const StyledLabel = styled.label`
 
 const Checkbox: FC<Props> = ({ id, checked = false, onChange, children, ...rest }) => (
   <StyledCheckbox {...rest}>
-    <StyledInput id={id} onChange={onChange} type="checkbox" checked={checked} />
+    <StyledInput id={id} onChange={onChange} type="checkbox" checked={checked} aria-checked={checked} />
     <StyledLabel htmlFor={id}>{children}</StyledLabel>
   </StyledCheckbox>
 )

--- a/components/styled/input/src/atoms/checkbox.tsx
+++ b/components/styled/input/src/atoms/checkbox.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FC, HTMLAttributes, InputHTMLAttributes } from 'react'
+import { FC, InputHTMLAttributes } from 'react'
 import styled from '@emotion/styled'
 import { BADGE_COLOURS } from '@ltht-react/styles'
 
@@ -54,11 +54,8 @@ const Checkbox: FC<Props> = ({ id, checked = false, onChange, children, ...rest 
   </StyledCheckbox>
 )
 
-interface Props extends HTMLAttributes<HTMLDivElement> {
-  id: string
-  checked: boolean
+interface Props extends InputHTMLAttributes<HTMLInputElement> {
   children: React.ReactNode
-  onChange(e: ChangeEvent<HTMLInputElement>): void
 }
 
 export default Checkbox

--- a/packages/storybook/src/ui/atoms/inputs/checkbox.stories.tsx
+++ b/packages/storybook/src/ui/atoms/inputs/checkbox.stories.tsx
@@ -1,0 +1,22 @@
+import { useState } from 'react'
+import { Story } from '@storybook/react'
+import { Checkbox } from '@ltht-react/input'
+import Card from '@ltht-react/card'
+
+// eslint-disable-next-line import/prefer-default-export
+export const CheckboxInput: Story = () => {
+  const [checkbox, setCheckbox] = useState(false)
+
+  return (
+    <>
+      <Card>
+        <Card.Header>Checkbox with label</Card.Header>
+        <Card.Body>
+          <Checkbox onChange={(e) => setCheckbox(e.target.checked)} id="storyCheckbox" checked={checkbox}>
+            Click me
+          </Checkbox>
+        </Card.Body>
+      </Card>
+    </>
+  )
+}

--- a/packages/storybook/src/ui/atoms/inputs/checkbox.test.tsx
+++ b/packages/storybook/src/ui/atoms/inputs/checkbox.test.tsx
@@ -1,0 +1,49 @@
+import { Checkbox } from '@ltht-react/input'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+describe('checkbox', () => {
+  it('should show a label', async () => {
+    render(
+      <Checkbox onChange={jest.fn()} checked={false} id="checkbox-id">
+        Checkbox label
+      </Checkbox>
+    )
+
+    await screen.findByText('Checkbox label')
+  })
+
+  it('should call back with the opposite value when you click the label', async () => {
+    const callback = jest.fn()
+
+    render(
+      <Checkbox onChange={callback} checked={false} id="checkbox-id">
+        Checkbox label
+      </Checkbox>
+    )
+
+    const label = await screen.findByText('Checkbox label')
+
+    userEvent.click(label)
+
+    expect(callback).toHaveBeenLastCalledWith(expect.objectContaining({ target: expect.anything() }))
+  })
+
+  it('should call back with the opposite value when you click the checkbox', async () => {
+    const callback = jest.fn()
+
+    render(
+      <Checkbox onChange={callback} checked={false} id="checkbox-id">
+        Checkbox label
+      </Checkbox>
+    )
+
+    const input = await screen.findByLabelText('Checkbox label')
+
+    userEvent.click(input)
+
+    expect(callback).toHaveBeenLastCalledWith(
+      expect.objectContaining({ target: expect.objectContaining({ checked: expect.anything() }) })
+    )
+  })
+})

--- a/packages/storybook/src/ui/atoms/inputs/checkbox.test.tsx
+++ b/packages/storybook/src/ui/atoms/inputs/checkbox.test.tsx
@@ -46,4 +46,16 @@ describe('checkbox', () => {
       expect.objectContaining({ target: expect.objectContaining({ checked: expect.anything() }) })
     )
   })
+
+  it('should expose the checked state for assistive technology', async () => {
+    render(
+      <Checkbox onChange={jest.fn()} checked={false} id="checkbox-id">
+        Checkbox label
+      </Checkbox>
+    )
+
+    const input = await screen.findByLabelText('Checkbox label')
+
+    expect(input).toHaveAttribute('aria-checked', 'false')
+  })
 })

--- a/packages/storybook/src/ui/atoms/inputs/index.stories.tsx
+++ b/packages/storybook/src/ui/atoms/inputs/index.stories.tsx
@@ -2,5 +2,6 @@ export * from './daypicker.stories'
 export * from './daypicker-range.stories'
 export * from './text.stories'
 export * from './toggle.stories'
+export * from './checkbox.stories'
 
 export default { title: 'UI/Atoms/Input' }


### PR DESCRIPTION
This (currently unused) component called Checkbox actually rendered a radio button input.

Swapping it out for a checkbox and styling it based on requirements from a UI mockup of upcoming care plan questionnaires:
![image](https://user-images.githubusercontent.com/22618005/201665349-bd9d60f8-0248-42f7-85a5-e6f9e0c70cbc.png)

Bonus story and tests added too

Should still render somewhat usably in IE 11
