### PR TITLE
Add admin actions column mapping to questionnaire table

### DIFF
--- a/components/styled/table/package.json
+++ b/components/styled/table/package.json
@@ -29,6 +29,7 @@
     "@emotion/styled": "^11.0.0",
     "@ltht-react/button": "^1.3.160",
     "@ltht-react/icon": "^1.3.160",
+    "ltht-react/menu": "^1.0.2",
     "@ltht-react/styles": "^1.3.152",
     "@ltht-react/types": "^1.0.156",
     "@ltht-react/utils": "^1.1.158",

--- a/components/styled/table/package.json
+++ b/components/styled/table/package.json
@@ -29,7 +29,7 @@
     "@emotion/styled": "^11.0.0",
     "@ltht-react/button": "^1.3.160",
     "@ltht-react/icon": "^1.3.160",
-    "ltht-react/menu": "^1.0.2",
+    "@ltht-react/menu": "^1.0.2",
     "@ltht-react/styles": "^1.3.152",
     "@ltht-react/types": "^1.0.156",
     "@ltht-react/utils": "^1.1.158",

--- a/components/styled/table/src/molecules/table-cell.tsx
+++ b/components/styled/table/src/molecules/table-cell.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react'
 import { Button } from '@ltht-react/button'
 import styled from '@emotion/styled'
 import { Icon, IconButton, IconProps } from '@ltht-react/icon'
+import ActionMenu, { ActionMenuOption } from '@ltht-react/menu'
 
 const StyledText = styled.span`
   margin-left: 0.4rem;
@@ -11,9 +12,20 @@ const StyledText = styled.span`
 // May be best to split it out into different components, the important part is unifying Type used by React-Table so the mapping can be simplified
 // It will need to facilitate the Actions list capability Jonny Dyson has requested
 // Betters ways of handling the customComponentOverride will be considered too
-const TableCell: FC<CellProps> = ({ isButton = false, text, iconProps, clickHandler, customComponentOverride }) => {
+const TableCell: FC<CellProps> = ({
+  adminActions,
+  isButton = false,
+  text,
+  iconProps,
+  clickHandler,
+  customComponentOverride,
+}) => {
   if (customComponentOverride) {
     return customComponentOverride
+  }
+
+  if (adminActions) {
+    return <ActionMenu actions={adminActions} />
   }
 
   if (isButton) {
@@ -41,6 +53,7 @@ const TableCell: FC<CellProps> = ({ isButton = false, text, iconProps, clickHand
 }
 
 export interface CellProps {
+  adminActions?: ActionMenuOption[]
   isButton?: boolean
   text?: string
   iconProps?: IconProps

--- a/components/styled/table/src/organisms/questionnaire-table-methods.ts
+++ b/components/styled/table/src/organisms/questionnaire-table-methods.ts
@@ -50,9 +50,9 @@ const mapQuestionnaireObjectsToHorizontalTableData = (
   }
 
   if (adminActions) {
-    tableData.headers = tableData.headers.splice(1, 0, {
+    tableData.headers.splice(1, 0, {
       id: 'adminactions',
-      type: 'display',
+      type: 'accessor',
       cellProps: { text: 'Actions' },
     })
   }

--- a/components/styled/table/src/organisms/questionnaire-table.tsx
+++ b/components/styled/table/src/organisms/questionnaire-table.tsx
@@ -2,14 +2,15 @@ import { QuestionnaireResponse, Axis, Questionnaire } from '@ltht-react/types'
 import { FC, useMemo } from 'react'
 import { Icon } from '@ltht-react/icon'
 import Table from '../molecules/table'
-import mapQuestionnaireDefinitionAndResponsesToTableData from './questionnaire-table-methods'
+import mapQuestionnaireDefinitionAndResponsesToTableData, {
+  AdminActionsForQuestionnaire,
+} from './questionnaire-table-methods'
 
-const QuestionnaireTable: FC<IProps> = ({ definition, records, headerAxis = 'y' }) => {
-  const tableData = useMemo(() => mapQuestionnaireDefinitionAndResponsesToTableData(definition, records, headerAxis), [
-    headerAxis,
-    definition,
-    records,
-  ])
+const QuestionnaireTable: FC<IProps> = ({ definition, records, headerAxis = 'y', adminActions }) => {
+  const tableData = useMemo(
+    () => mapQuestionnaireDefinitionAndResponsesToTableData(definition, records, headerAxis, adminActions),
+    [headerAxis, definition, records]
+  )
 
   // TODO: Replace this fragment with a properly styled error component.
   // Maybe this could be a re-usable atom?
@@ -29,6 +30,7 @@ interface IProps {
   definition: Questionnaire
   records: QuestionnaireResponse[]
   headerAxis?: Axis
+  adminActions?: AdminActionsForQuestionnaire[]
 }
 
 export default QuestionnaireTable

--- a/components/styled/table/src/organisms/questionnaire-table.tsx
+++ b/components/styled/table/src/organisms/questionnaire-table.tsx
@@ -9,7 +9,7 @@ import mapQuestionnaireDefinitionAndResponsesToTableData, {
 const QuestionnaireTable: FC<IProps> = ({ definition, records, headerAxis = 'y', adminActions }) => {
   const tableData = useMemo(
     () => mapQuestionnaireDefinitionAndResponsesToTableData(definition, records, headerAxis, adminActions),
-    [headerAxis, definition, records]
+    [headerAxis, definition, records, adminActions]
   )
 
   // TODO: Replace this fragment with a properly styled error component.

--- a/packages/storybook/src/ui/organisms/questionnaire-table/questionnaire-table.fixtures.ts
+++ b/packages/storybook/src/ui/organisms/questionnaire-table/questionnaire-table.fixtures.ts
@@ -1,3 +1,4 @@
+import { AdminActionsForQuestionnaire } from '@ltht-react/table/src/organisms/questionnaire-table-methods'
 import {
   PartialDateTimeKindCode,
   Questionnaire,
@@ -768,5 +769,91 @@ const summaryRecordThree = {
   ],
 }
 
-// this should be the actual data we pass in, but I've commented it out for simplicity
+export const adminActionsForForms: AdminActionsForQuestionnaire[] = [
+  {
+    questionnaire: '1',
+    adminActions: [
+      {
+        text: 'View',
+        clickHandler: () => {
+          console.log('Viewing submission 1')
+        },
+        leftIcon: { type: 'info-circle', size: 'medium' },
+        rightIcon: { type: 'external-link', size: 'medium' },
+      },
+      {
+        text: 'Edit',
+        clickHandler: () => {
+          console.log('Editing submission 1')
+        },
+        leftIcon: { type: 'edit', size: 'medium' },
+        rightIcon: { type: 'external-link', size: 'medium' },
+      },
+      {
+        text: 'Delete',
+        clickHandler: () => {
+          console.log('Deleting submission 1')
+        },
+        leftIcon: { type: 'exclamation', size: 'medium' },
+      },
+    ],
+  },
+  {
+    questionnaire: '2',
+    adminActions: [
+      {
+        text: 'View',
+        clickHandler: () => {
+          console.log('Viewing submission 2')
+        },
+        leftIcon: { type: 'info-circle', size: 'medium' },
+        rightIcon: { type: 'external-link', size: 'medium' },
+      },
+      {
+        text: 'Edit',
+        clickHandler: () => {
+          console.log('Editing submission 2')
+        },
+        leftIcon: { type: 'edit', size: 'medium' },
+        rightIcon: { type: 'external-link', size: 'medium' },
+      },
+      {
+        text: 'Delete',
+        clickHandler: () => {
+          console.log('Deleting submission 2')
+        },
+        leftIcon: { type: 'exclamation', size: 'medium' },
+      },
+    ],
+  },
+  {
+    questionnaire: '3',
+    adminActions: [
+      {
+        text: 'View',
+        clickHandler: () => {
+          console.log('Viewing submission 3')
+        },
+        leftIcon: { type: 'info-circle', size: 'medium' },
+        rightIcon: { type: 'external-link', size: 'medium' },
+      },
+      {
+        text: 'Edit',
+        clickHandler: () => {
+          console.log('Editing submission 3')
+        },
+        leftIcon: { type: 'edit', size: 'medium' },
+        rightIcon: { type: 'external-link', size: 'medium' },
+      },
+      {
+        text: 'Delete',
+        clickHandler: () => {
+          console.log('Deleting submission 3')
+        },
+        leftIcon: { type: 'exclamation', size: 'medium' },
+      },
+    ],
+  },
+]
+
 export const summaryRecordsList: QuestionnaireResponse[] = [summaryRecordOne, summaryRecordTwo, summaryRecordThree]

--- a/packages/storybook/src/ui/organisms/questionnaire-table/questionnaire-table.fixtures.ts
+++ b/packages/storybook/src/ui/organisms/questionnaire-table/questionnaire-table.fixtures.ts
@@ -1,3 +1,4 @@
+/* eslint no-console: 0 */
 import { AdminActionsForQuestionnaire } from '@ltht-react/table/src/organisms/questionnaire-table-methods'
 import {
   PartialDateTimeKindCode,

--- a/packages/storybook/src/ui/organisms/questionnaire-table/questionnaire-table.mockdata.tsx
+++ b/packages/storybook/src/ui/organisms/questionnaire-table/questionnaire-table.mockdata.tsx
@@ -1,8 +1,10 @@
 import { TableData } from '@ltht-react/table'
+import { AdminActionsForQuestionnaire } from '@ltht-react/table/lib/organisms/questionnaire-table-methods'
 
 export const expectedResultOfMappingWithHeadersOnXAxis: TableData = {
   headers: [
     { id: 'date', type: 'accessor', cellProps: { text: 'Record Date' } },
+    { id: 'adminactions', type: 'accessor', cellProps: { text: 'Actions' } },
     { id: '1', type: 'accessor', cellProps: { text: 'Score' }, subHeaders: [] },
     { id: '2', type: 'accessor', cellProps: { text: 'Intervention' }, subHeaders: [] },
     { id: '3', type: 'accessor', cellProps: { text: 'Partial Indication' }, subHeaders: [] },
@@ -36,6 +38,18 @@ export const expectedResultOfMappingWithHeadersOnXAxis: TableData = {
   rows: [
     {
       date: { text: '17-Feb-2022 17:23' },
+      adminactions: {
+        adminActions: [
+          {
+            text: 'View',
+            clickHandler: () => {
+              console.log('Viewing submission 1')
+            },
+            leftIcon: { type: 'info-circle', size: 'medium' },
+            rightIcon: { type: 'external-link', size: 'medium' },
+          },
+        ],
+      },
       '1': { text: '5 NEWS' },
       '2': { text: 'ICON' },
       '3': { text: 'No' },
@@ -56,6 +70,18 @@ export const expectedResultOfMappingWithHeadersOnXAxis: TableData = {
     },
     {
       date: { text: '12-Feb-2022 12:33' },
+      adminactions: {
+        adminActions: [
+          {
+            text: 'View',
+            clickHandler: () => {
+              console.log('Viewing submission 2')
+            },
+            leftIcon: { type: 'info-circle', size: 'medium' },
+            rightIcon: { type: 'external-link', size: 'medium' },
+          },
+        ],
+      },
       '1': { text: '40 NEWS' },
       '2': { text: 'ICON' },
       '3': { text: 'Yes' },
@@ -76,6 +102,18 @@ export const expectedResultOfMappingWithHeadersOnXAxis: TableData = {
     },
     {
       date: { text: '01-Jan-2022 16:02' },
+      adminactions: {
+        adminActions: [
+          {
+            text: 'View',
+            clickHandler: () => {
+              console.log('Viewing submission 3')
+            },
+            leftIcon: { type: 'info-circle', size: 'medium' },
+            rightIcon: { type: 'external-link', size: 'medium' },
+          },
+        ],
+      },
       '1': { text: '17 NEWS' },
       '2': { text: 'ICON' },
       '3': { text: 'No' },
@@ -105,6 +143,45 @@ export const expectedResultOfMappingWithHeadersOnYAxis: TableData = {
     { id: '3', type: 'accessor', cellProps: { text: '01-Jan-2022 16:02' } },
   ],
   rows: [
+    {
+      property: { text: 'Actions' },
+      '1': {
+        adminActions: [
+          {
+            text: 'View',
+            clickHandler: () => {
+              console.log('Viewing submission 1')
+            },
+            leftIcon: { type: 'info-circle', size: 'medium' },
+            rightIcon: { type: 'external-link', size: 'medium' },
+          },
+        ],
+      },
+      '2': {
+        adminActions: [
+          {
+            text: 'View',
+            clickHandler: () => {
+              console.log('Viewing submission 2')
+            },
+            leftIcon: { type: 'info-circle', size: 'medium' },
+            rightIcon: { type: 'external-link', size: 'medium' },
+          },
+        ],
+      },
+      '3': {
+        adminActions: [
+          {
+            text: 'View',
+            clickHandler: () => {
+              console.log('Viewing submission 3')
+            },
+            leftIcon: { type: 'info-circle', size: 'medium' },
+            rightIcon: { type: 'external-link', size: 'medium' },
+          },
+        ],
+      },
+    },
     {
       property: { text: 'Score' },
       '1': { text: '5 NEWS' },
@@ -213,3 +290,45 @@ export const expectedResultOfMappingWithHeadersOnYAxis: TableData = {
     },
   ],
 }
+
+export const mockAdminActionsForForms: AdminActionsForQuestionnaire[] = [
+  {
+    questionnaire: '1',
+    adminActions: [
+      {
+        text: 'View',
+        clickHandler: () => {
+          console.log('Viewing submission 1')
+        },
+        leftIcon: { type: 'info-circle', size: 'medium' },
+        rightIcon: { type: 'external-link', size: 'medium' },
+      },
+    ],
+  },
+  {
+    questionnaire: '2',
+    adminActions: [
+      {
+        text: 'View',
+        clickHandler: () => {
+          console.log('Viewing submission 2')
+        },
+        leftIcon: { type: 'info-circle', size: 'medium' },
+        rightIcon: { type: 'external-link', size: 'medium' },
+      },
+    ],
+  },
+  {
+    questionnaire: '3',
+    adminActions: [
+      {
+        text: 'View',
+        clickHandler: () => {
+          console.log('Viewing submission 3')
+        },
+        leftIcon: { type: 'info-circle', size: 'medium' },
+        rightIcon: { type: 'external-link', size: 'medium' },
+      },
+    ],
+  },
+]

--- a/packages/storybook/src/ui/organisms/questionnaire-table/questionnaire-table.mockdata.tsx
+++ b/packages/storybook/src/ui/organisms/questionnaire-table/questionnaire-table.mockdata.tsx
@@ -1,3 +1,4 @@
+/* eslint no-console: 0 */
 import { TableData } from '@ltht-react/table'
 import { AdminActionsForQuestionnaire } from '@ltht-react/table/lib/organisms/questionnaire-table-methods'
 

--- a/packages/storybook/src/ui/organisms/questionnaire-table/questionnaire-table.stories.tsx
+++ b/packages/storybook/src/ui/organisms/questionnaire-table/questionnaire-table.stories.tsx
@@ -5,11 +5,16 @@ import { summaryDefinition, summaryRecordsList, adminActionsForForms } from './q
 export const VerticalTable: Story = () => (
   <QuestionnaireTable definition={summaryDefinition} records={summaryRecordsList} />
 )
+
+export const VerticalTableWithAdminActions: Story = () => (
+  <QuestionnaireTable definition={summaryDefinition} records={summaryRecordsList} adminActions={adminActionsForForms} />
+)
+
 export const HorizontalTable: Story = () => (
   <QuestionnaireTable definition={summaryDefinition} records={summaryRecordsList} headerAxis="x" />
 )
 
-export const QuestionnaireWithAdminActions: Story = () => (
+export const HorizontalTableAdminActions: Story = () => (
   <QuestionnaireTable
     definition={summaryDefinition}
     records={summaryRecordsList}

--- a/packages/storybook/src/ui/organisms/questionnaire-table/questionnaire-table.stories.tsx
+++ b/packages/storybook/src/ui/organisms/questionnaire-table/questionnaire-table.stories.tsx
@@ -1,12 +1,21 @@
 import { Story } from '@storybook/react'
 import { QuestionnaireTable } from '@ltht-react/table'
-import { summaryDefinition, summaryRecordsList } from './questionnaire-table.fixtures'
+import { summaryDefinition, summaryRecordsList, adminActionsForForms } from './questionnaire-table.fixtures'
 
 export const VerticalTable: Story = () => (
   <QuestionnaireTable definition={summaryDefinition} records={summaryRecordsList} />
 )
 export const HorizontalTable: Story = () => (
   <QuestionnaireTable definition={summaryDefinition} records={summaryRecordsList} headerAxis="x" />
+)
+
+export const QuestionnaireWithAdminActions: Story = () => (
+  <QuestionnaireTable
+    definition={summaryDefinition}
+    records={summaryRecordsList}
+    headerAxis="x"
+    adminActions={adminActionsForForms}
+  />
 )
 
 export default { title: 'UI/Organisms/QuestionnaireTable' }

--- a/packages/storybook/src/ui/organisms/questionnaire-table/questionnaire-table.test.tsx
+++ b/packages/storybook/src/ui/organisms/questionnaire-table/questionnaire-table.test.tsx
@@ -46,8 +46,9 @@ describe('Questionnaire Table (using Fixture data)', () => {
     expect(getTopLeftDataCell()).toHaveTextContent('Score')
 
     userEvent.click(screen.getByText('17-Feb-2022 17:23'))
+    userEvent.click(screen.getByText('17-Feb-2022 17:23'))
 
-    expect(getTopLeftDataCell()).toHaveTextContent('Partial Indication')
+    expect(getTopLeftDataCell()).toHaveTextContent('Standard Observations')
   })
 
   it('Sorts the table if the lowest level of subheaders are clicked in horizontal mode', () => {
@@ -59,7 +60,7 @@ describe('Questionnaire Table (using Fixture data)', () => {
 
     userEvent.click(screen.getByText('Record Date'))
 
-    expect(getTopLeftDataCell()).toHaveTextContent('01-Jan-2022 16:02')
+    expect(getTopLeftDataCell()).toHaveTextContent('17-Feb-2022 17:23')
   })
 
   it('Does not try to sort the table when a header grouping is clicked', () => {
@@ -79,17 +80,17 @@ describe('Questionnaire Table (using Fixture data)', () => {
 
     const getChevronCell = () => within(screen.getAllByRole('row')[4]).getAllByRole('cell')[0]
 
-    expect(getChevronCell()).toHaveTextContent('►')
+    expect(within(getChevronCell()).getByRole('img', { hidden: true })).toHaveClass('fa-chevron-right')
     expect(screen.getAllByRole('row').length).toBe(5)
 
-    userEvent.click(screen.getAllByText('►')[1])
+    userEvent.click(screen.getAllByRole('img', { hidden: true })[1])
 
-    expect(getChevronCell()).toHaveTextContent('▲')
+    expect(within(getChevronCell()).getByRole('img', { hidden: true })).toHaveClass('fa-chevron-down')
     expect(screen.getAllByRole('row').length).toBeGreaterThan(5)
     expect(screen.getAllByRole('row')[5]).toBeVisible()
 
-    userEvent.click(screen.getAllByText('▲')[0])
-    expect(getChevronCell()).toHaveTextContent('►')
+    userEvent.click(screen.getAllByRole('img', { hidden: true })[1])
+    expect(within(getChevronCell()).getByRole('img', { hidden: true })).toHaveClass('fa-chevron-right')
     expect(screen.getAllByRole('row').length).toBe(5)
   })
 
@@ -98,21 +99,21 @@ describe('Questionnaire Table (using Fixture data)', () => {
 
     const getChevronCell = () => within(screen.getAllByRole('row')[0]).getAllByRole('columnheader')[0]
 
-    expect(getChevronCell()).toHaveTextContent('►')
+    expect(within(getChevronCell()).getByRole('img', { hidden: true })).toHaveClass('fa-chevron-right')
     expect(screen.getAllByRole('row').length).toBe(5)
 
-    userEvent.click(screen.getAllByText('►')[0])
+    userEvent.click(screen.getAllByRole('img', { hidden: true })[0])
 
-    expect(getChevronCell()).toHaveTextContent('▲')
+    expect(within(getChevronCell()).getByRole('img', { hidden: true })).toHaveClass('fa-chevron-down')
     expect(screen.getAllByRole('row').length).toBeGreaterThan(5)
     expect(screen.getAllByRole('row')[5]).toBeVisible()
 
     expect(within(screen.getAllByRole('row')[6]).getAllByRole('cell')[1]).toHaveTextContent('RR Part 1 (breaths/min)')
     expect(within(screen.getAllByRole('row')[7]).getAllByRole('cell')[1]).toHaveTextContent('RR Part 2 (breaths/min)')
 
-    userEvent.click(screen.getAllByText('▲')[0])
+    userEvent.click(within(getChevronCell()).getByRole('img', { hidden: true }))
+    expect(within(getChevronCell()).getByRole('img', { hidden: true })).toHaveClass('fa-chevron-right')
 
-    expect(getChevronCell()).toHaveTextContent('►')
     expect(screen.getAllByRole('row').length).toBe(5)
   })
 })
@@ -193,7 +194,7 @@ describe('Questionnaire Table Methods', () => {
     expect(result).toEqual(expectedResultOfMappingWithHeadersOnXAxis)
   })
 
-  it.only('Maps questionnaires data with headers along the Y axis', () => {
+  it('Maps questionnaires data with headers along the Y axis', () => {
     const result = mapQuestionnaireDefinitionAndResponsesToTableData(summaryDefinition, summaryRecordsList, 'y')
 
     expect(result).toEqual(expectedResultOfMappingWithHeadersOnYAxis)

--- a/packages/storybook/src/ui/organisms/questionnaire-table/questionnaire-table.test.tsx
+++ b/packages/storybook/src/ui/organisms/questionnaire-table/questionnaire-table.test.tsx
@@ -8,6 +8,7 @@ import { summaryDefinition, summaryRecordsList } from './questionnaire-table.fix
 import {
   expectedResultOfMappingWithHeadersOnXAxis,
   expectedResultOfMappingWithHeadersOnYAxis,
+  mockAdminActionsForForms,
 } from './questionnaire-table.mockdata'
 
 describe('Questionnaire Table (using Fixture data)', () => {
@@ -189,14 +190,24 @@ describe('Questionnaire Table (using mock Monty Python data)', () => {
 
 describe('Questionnaire Table Methods', () => {
   it('Maps questionnaires data with headers along the X axis', () => {
-    const result = mapQuestionnaireDefinitionAndResponsesToTableData(summaryDefinition, summaryRecordsList, 'x')
+    const result = mapQuestionnaireDefinitionAndResponsesToTableData(
+      summaryDefinition,
+      summaryRecordsList,
+      'x',
+      mockAdminActionsForForms
+    )
 
-    expect(result).toEqual(expectedResultOfMappingWithHeadersOnXAxis)
+    expect(JSON.stringify(result)).toEqual(JSON.stringify(expectedResultOfMappingWithHeadersOnXAxis))
   })
 
   it('Maps questionnaires data with headers along the Y axis', () => {
-    const result = mapQuestionnaireDefinitionAndResponsesToTableData(summaryDefinition, summaryRecordsList, 'y')
+    const result = mapQuestionnaireDefinitionAndResponsesToTableData(
+      summaryDefinition,
+      summaryRecordsList,
+      'y',
+      mockAdminActionsForForms
+    )
 
-    expect(result).toEqual(expectedResultOfMappingWithHeadersOnYAxis)
+    expect(JSON.stringify(result)).toEqual(JSON.stringify(expectedResultOfMappingWithHeadersOnYAxis))
   })
 })


### PR DESCRIPTION
Allows the consumer of the Questionnaire Table organism to supply a list of admin actions for each Questionnaire Response, and have this mapped into the TableData automatically using the new Menu molecule.
![01](https://user-images.githubusercontent.com/63285990/202056562-e91e6040-4ba4-46e5-8430-d8041d9a8e92.jpg)
![02](https://user-images.githubusercontent.com/63285990/202056576-11091989-dfa1-4fbe-a51c-271a020cde00.jpg)
