### PR TITLE
Export AdminActions interface so ehr-client can use it

### DIFF
--- a/components/styled/table/src/index.tsx
+++ b/components/styled/table/src/index.tsx
@@ -1,6 +1,7 @@
 import Table, { Header, DataEntity, TableData } from './molecules/table'
 import GenericTable from './organisms/generic-table'
 import QuestionnaireTable from './organisms/questionnaire-table'
+import { AdminActionsForQuestionnaire } from './organisms/questionnaire-table-methods'
 
 export default Table
-export { Header, TableData, DataEntity, GenericTable, QuestionnaireTable }
+export { Header, TableData, DataEntity, GenericTable, QuestionnaireTable, AdminActionsForQuestionnaire }


### PR DESCRIPTION
EHR Client is going to map a list of admin actions from the list of QuestionnaireResponses it receives and pass these into the Table component. It's helpful to it if the interface it's creating an array of is exported.