### PR TITLE
Keep previous data for manual pagination flag

### DIFF
--- a/components/styled/table/src/molecules/table-methods.tsx
+++ b/components/styled/table/src/molecules/table-methods.tsx
@@ -209,12 +209,13 @@ const calculateSliceStartPoint = (oldLength: number, usingExpanderColumn: boolea
 const handleDataUpdateForManualPagination = (
   tableData: TableData,
   headerAxis: Axis,
+  keepPreviousData: boolean,
   setColumns: (value: React.SetStateAction<ColumnDef<DataEntity>[]>) => void,
   setData: (value: React.SetStateAction<DataEntity[]>) => void
 ) => {
   if (headerAxis === 'x') {
     setData((old) => {
-      const newData = [...old, ...tableData.rows]
+      const newData = keepPreviousData ? [...old, ...tableData.rows] : tableData.rows
       setColumns(createColumns({ headers: tableData.headers, rows: newData }))
       return newData
     })
@@ -226,7 +227,7 @@ const handleDataUpdateForManualPagination = (
         tableData.rows.some((x) => x.subRows)
       )
 
-      return [...old, ...newColumns.slice(sliceStartPoint, newColumns.length)]
+      return keepPreviousData ? [...old, ...newColumns.slice(sliceStartPoint, newColumns.length)] : newColumns
     })
     setData(tableData.rows)
   }

--- a/components/styled/table/src/molecules/table-styled-components.tsx
+++ b/components/styled/table/src/molecules/table-styled-components.tsx
@@ -13,9 +13,13 @@ import { Axis } from '@ltht-react/types'
 const ScrollableContainer = styled.div<IScrollableContainer>`
   ${CSS_RESET};
   background-color: white;
-  display: ${({ tableHeaderAxis }) => (tableHeaderAxis === 'y' ? 'inline-flex' : 'inline-block')};
-  max-width: 100%;
-  max-height: 100%;
+  ${({ tableHeaderAxis, maxWidth, maxHeight }) => {
+    return `
+      display: ${tableHeaderAxis === 'y' ? 'inline-flex' : 'inline-block'};
+      max-width: ${maxWidth ? maxWidth : '100%'};
+      max-height: ${maxHeight ? maxHeight : '100%'};
+    `
+  }}
   border-radius: 6px;
   overflow: auto;
   &::-webkit-scrollbar {
@@ -182,6 +186,8 @@ interface IStyledNextPageButtonContainer {
 
 interface IScrollableContainer {
   tableHeaderAxis: Axis
+  maxHeight?: string
+  maxWidth?: string
 }
 
 export {

--- a/components/styled/table/src/molecules/table-styled-components.tsx
+++ b/components/styled/table/src/molecules/table-styled-components.tsx
@@ -15,8 +15,8 @@ const ScrollableContainer = styled.div<IScrollableContainer>`
   background-color: white;
   ${({ tableHeaderAxis, maxWidth, maxHeight }) => `
     display: ${tableHeaderAxis === 'y' ? 'inline-flex' : 'inline-block'};
-    max-width: ${maxWidth ? maxWidth : '100%'};
-    max-height: ${maxHeight ? maxHeight : '100%'};
+    max-width: ${maxWidth ?? '100%'};
+    max-height: ${maxHeight ?? '100%'};
   `}
   border-radius: 6px;
   overflow: auto;

--- a/components/styled/table/src/molecules/table-styled-components.tsx
+++ b/components/styled/table/src/molecules/table-styled-components.tsx
@@ -13,13 +13,11 @@ import { Axis } from '@ltht-react/types'
 const ScrollableContainer = styled.div<IScrollableContainer>`
   ${CSS_RESET};
   background-color: white;
-  ${({ tableHeaderAxis, maxWidth, maxHeight }) => {
-    return `
-      display: ${tableHeaderAxis === 'y' ? 'inline-flex' : 'inline-block'};
-      max-width: ${maxWidth ? maxWidth : '100%'};
-      max-height: ${maxHeight ? maxHeight : '100%'};
-    `
-  }}
+  ${({ tableHeaderAxis, maxWidth, maxHeight }) => `
+    display: ${tableHeaderAxis === 'y' ? 'inline-flex' : 'inline-block'};
+    max-width: ${maxWidth ? maxWidth : '100%'};
+    max-height: ${maxHeight ? maxHeight : '100%'};
+  `}
   border-radius: 6px;
   overflow: auto;
   &::-webkit-scrollbar {

--- a/components/styled/table/src/molecules/table.tsx
+++ b/components/styled/table/src/molecules/table.tsx
@@ -31,6 +31,7 @@ const Table: FC<IProps> = ({
   getCanNextPage = () => false,
   nextPage = () => null,
   isFetching = false,
+  keepPreviousData = false,
 }) => {
   const scrollableDivElement = useRef(null)
   const scrollState = useScrollRef(scrollableDivElement)
@@ -43,7 +44,6 @@ const Table: FC<IProps> = ({
   })
 
   const pagination = useMemo(() => ({ pageIndex, pageSize }), [pageIndex, pageSize])
-
   const [data, setData] = useState<DataEntity[]>([])
   const [columns, setColumns] = useState<ColumnDef<DataEntity>[]>([])
   const [pageCount, setPageCount] = useState<number>(-1)
@@ -56,9 +56,9 @@ const Table: FC<IProps> = ({
 
   useEffect(() => {
     if (manualPagination) {
-      handleDataUpdateForManualPagination(tableData, headerAxis, setColumns, setData)
+      handleDataUpdateForManualPagination(tableData, headerAxis, keepPreviousData, setColumns, setData)
     }
-  }, [headerAxis, tableData, manualPagination])
+  }, [headerAxis, tableData, manualPagination, keepPreviousData])
 
   const table = useReactTable({
     data,
@@ -134,6 +134,7 @@ interface IProps {
   nextPage?: () => void
   getCanNextPage?: () => boolean
   isFetching?: boolean
+  keepPreviousData?: boolean
 }
 
 type DataEntity = Record<string, CellProps | DataEntity[]> & {

--- a/components/styled/table/src/molecules/table.tsx
+++ b/components/styled/table/src/molecules/table.tsx
@@ -32,6 +32,8 @@ const Table: FC<IProps> = ({
   nextPage = () => null,
   isFetching = false,
   keepPreviousData = false,
+  maxHeight,
+  maxWidth,
 }) => {
   const scrollableDivElement = useRef(null)
   const scrollState = useScrollRef(scrollableDivElement)
@@ -108,33 +110,39 @@ const Table: FC<IProps> = ({
   }
 
   return (
-    <>
-      <ScrollableContainer ref={scrollableDivElement} tableHeaderAxis={headerAxis}>
-        <TableComponent table={table} staticColumns={staticColumns} />
-        {manualPagination ? (
-          <TableSpinner position={headerAxis === 'x' ? 'bottom' : 'right'} hidden={!isFetching} />
-        ) : null}
-        <TableNavigationButton
-          position={headerAxis === 'x' ? 'bottom' : 'right'}
-          hidden={isFetching || (manualPagination ? !getCanNextPage() : !table.getCanNextPage())}
-          clickHandler={getNextPage}
-        />
-      </ScrollableContainer>
-    </>
+    <ScrollableContainer ref={scrollableDivElement} tableHeaderAxis={headerAxis} {...{ maxHeight, maxWidth }}>
+      <TableComponent table={table} staticColumns={staticColumns} />
+      {manualPagination ? (
+        <TableSpinner position={headerAxis === 'x' ? 'bottom' : 'right'} hidden={!isFetching} />
+      ) : null}
+      <TableNavigationButton
+        position={headerAxis === 'x' ? 'bottom' : 'right'}
+        hidden={isFetching || (manualPagination ? !getCanNextPage() : !table.getCanNextPage())}
+        clickHandler={getNextPage}
+      />
+    </ScrollableContainer>
   )
 }
 
-interface IProps {
+interface IProps extends IPaginationProps, ITableDimensionProps {
   tableData: TableData
   staticColumns?: 0 | 1 | 2
+  headerAxis?: Axis
+}
+
+export interface IPaginationProps {
   currentPage?: number
   pageSize?: number
-  headerAxis?: Axis
   manualPagination?: boolean
   nextPage?: () => void
   getCanNextPage?: () => boolean
   isFetching?: boolean
   keepPreviousData?: boolean
+}
+
+export interface ITableDimensionProps {
+  maxWidth?: string
+  maxHeight?: string
 }
 
 type DataEntity = Record<string, CellProps | DataEntity[]> & {

--- a/components/styled/table/src/organisms/generic-table.tsx
+++ b/components/styled/table/src/organisms/generic-table.tsx
@@ -8,12 +8,20 @@ const GenericTable = <TColumn, TRow>({
   headerAxis = 'x',
   pageSize = 10,
   currentPage = 1,
+  keepPreviousData = true,
   ...props
 }: IProps<TColumn, TRow>) => {
   const tableData = mapToTableData(columnData, rowData)
 
   return (
-    <Table tableData={tableData} headerAxis={headerAxis} pageSize={pageSize} currentPage={currentPage} {...props} />
+    <Table
+      tableData={tableData}
+      headerAxis={headerAxis}
+      pageSize={pageSize}
+      currentPage={currentPage}
+      keepPreviousData={keepPreviousData}
+      {...props}
+    />
   )
 }
 
@@ -28,6 +36,7 @@ interface IProps<TColumn, TRow> {
   nextPage?: () => void
   getCanNextPage?: () => boolean
   isFetching?: boolean
+  keepPreviousData?: boolean
 }
 
 export default GenericTable

--- a/components/styled/table/src/organisms/generic-table.tsx
+++ b/components/styled/table/src/organisms/generic-table.tsx
@@ -1,5 +1,5 @@
 import { Axis } from '@ltht-react/types'
-import Table, { TableData } from '../molecules/table'
+import Table, { IPaginationProps, ITableDimensionProps, TableData } from '../molecules/table'
 
 const GenericTable = <TColumn, TRow>({
   columnData,
@@ -25,18 +25,11 @@ const GenericTable = <TColumn, TRow>({
   )
 }
 
-interface IProps<TColumn, TRow> {
+interface IProps<TColumn, TRow> extends IPaginationProps, ITableDimensionProps {
   columnData: TColumn
   rowData: TRow
   mapToTableData: (colData: TColumn, rowData: TRow) => TableData
   headerAxis?: Axis
-  currentPage?: number
-  pageSize?: number
-  manualPagination?: boolean
-  nextPage?: () => void
-  getCanNextPage?: () => boolean
-  isFetching?: boolean
-  keepPreviousData?: boolean
 }
 
 export default GenericTable

--- a/components/styled/table/src/organisms/questionnaire-table.tsx
+++ b/components/styled/table/src/organisms/questionnaire-table.tsx
@@ -14,6 +14,7 @@ const QuestionnaireTable: FC<IProps> = ({
   adminActions,
   pageSize = 10,
   currentPage = 1,
+  keepPreviousData = true,
   ...props
 }) => {
   const tableData = useMemo(
@@ -39,6 +40,7 @@ const QuestionnaireTable: FC<IProps> = ({
       headerAxis={headerAxis}
       pageSize={pageSize}
       currentPage={currentPage}
+      keepPreviousData={keepPreviousData}
       {...props}
     />
   )
@@ -56,6 +58,7 @@ interface IProps {
   nextPage?: () => void
   getCanNextPage?: () => boolean
   isFetching?: boolean
+  keepPreviousData?: boolean
 }
 
 export default QuestionnaireTable

--- a/components/styled/table/src/organisms/questionnaire-table.tsx
+++ b/components/styled/table/src/organisms/questionnaire-table.tsx
@@ -1,7 +1,7 @@
 import { QuestionnaireResponse, Axis, Questionnaire } from '@ltht-react/types'
 import { FC, useMemo } from 'react'
 import { Icon } from '@ltht-react/icon'
-import Table from '../molecules/table'
+import Table, { IPaginationProps, ITableDimensionProps } from '../molecules/table'
 import mapQuestionnaireDefinitionAndResponsesToTableData, {
   AdminActionsForQuestionnaire,
 } from './questionnaire-table-methods'
@@ -46,19 +46,12 @@ const QuestionnaireTable: FC<IProps> = ({
   )
 }
 
-interface IProps {
+interface IProps extends IPaginationProps, ITableDimensionProps {
   definition: Questionnaire
   records: QuestionnaireResponse[]
   headerAxis?: Axis
   adminActions?: AdminActionsForQuestionnaire[]
   staticColumns?: 0 | 1 | 2
-  currentPage?: number
-  pageSize?: number
-  manualPagination?: boolean
-  nextPage?: () => void
-  getCanNextPage?: () => boolean
-  isFetching?: boolean
-  keepPreviousData?: boolean
 }
 
 export default QuestionnaireTable

--- a/packages/storybook/src/ui/molecules/table/table.test.tsx
+++ b/packages/storybook/src/ui/molecules/table/table.test.tsx
@@ -165,6 +165,7 @@ describe('Table with infinite scroll pagination (x) [MANUAL]', () => {
           getCanNextPage={mockGetCanNextPageHandler}
           headerAxis="x"
           manualPagination
+          keepPreviousData
         />
       </div>
     )
@@ -195,6 +196,7 @@ describe('Table with infinite scroll pagination (x) [MANUAL]', () => {
           getCanNextPage={mockGetCanNextPageHandler}
           headerAxis="x"
           manualPagination
+          keepPreviousData
         />
       </div>
     )
@@ -244,6 +246,7 @@ describe('Table with infinite scroll pagination (y) [MANUAL]', () => {
           getCanNextPage={mockGetCanNextPageHandler}
           headerAxis="y"
           manualPagination
+          keepPreviousData
         />
       </div>
     )
@@ -274,6 +277,7 @@ describe('Table with infinite scroll pagination (y) [MANUAL]', () => {
           getCanNextPage={mockGetCanNextPageHandler}
           headerAxis="y"
           manualPagination
+          keepPreviousData
         />
       </div>
     )

--- a/packages/storybook/src/ui/molecules/table/table.test.tsx
+++ b/packages/storybook/src/ui/molecules/table/table.test.tsx
@@ -153,6 +153,37 @@ describe('Table with infinite scroll pagination (x) [MANUAL]', () => {
     rows: mockTableDataForPagination.rows.slice(pageIndex * pageSize, (pageIndex + 1) * pageSize),
   })
 
+  it('navigates to next page using the button (NOT keeping previous data)', async () => {
+    const mockNextPageHandler = jest.fn(() => null)
+    const mockGetCanNextPageHandler = jest.fn(() => true)
+
+    const getTable = (pageIndex: number) => (
+      <div style={{ height: '400px' }}>
+        <Table
+          tableData={getPaginatedData(pageIndex, 10)}
+          nextPage={mockNextPageHandler}
+          getCanNextPage={mockGetCanNextPageHandler}
+          headerAxis="x"
+          manualPagination
+          keepPreviousData={false}
+        />
+      </div>
+    )
+
+    const { rerender } = render(getTable(0))
+
+    expect(screen.getAllByRole('row').length).toEqual(11)
+
+    userEvent.click(screen.getByRole('button'))
+
+    rerender(getTable(1))
+
+    expect(within(screen.getByRole('table')).getAllByRole('row').length).toEqual(11)
+
+    expect(mockGetCanNextPageHandler).toHaveBeenCalled()
+    expect(mockNextPageHandler).toHaveBeenCalled()
+  })
+
   it('navigates to next page using the button when scroll is not available', async () => {
     const mockNextPageHandler = jest.fn(() => null)
     const mockGetCanNextPageHandler = jest.fn(() => true)
@@ -232,6 +263,37 @@ describe('Table with infinite scroll pagination (y) [MANUAL]', () => {
         .slice(pageIndex * pageSize, (pageIndex + 1) * pageSize),
     ],
     rows: mockTableDataForVerticalPagination.rows,
+  })
+
+  it('navigates to next page using the button (NOT Keeping Previous Data)', () => {
+    const mockNextPageHandler = jest.fn(() => null)
+    const mockGetCanNextPageHandler = jest.fn(() => true)
+
+    const getTable = (pageIndex: number) => (
+      <div style={{ maxWidth: '100%' }}>
+        <Table
+          tableData={getPaginatedData(pageIndex, 10)}
+          nextPage={mockNextPageHandler}
+          getCanNextPage={mockGetCanNextPageHandler}
+          headerAxis="y"
+          manualPagination
+          keepPreviousData={false}
+        />
+      </div>
+    )
+
+    const { rerender } = render(getTable(0))
+
+    expect(screen.getAllByRole('columnheader').length).toEqual(11)
+
+    userEvent.click(screen.getByRole('button'))
+
+    rerender(getTable(1))
+
+    expect(screen.getAllByRole('columnheader').length).toEqual(11)
+
+    expect(mockGetCanNextPageHandler).toHaveBeenCalled()
+    expect(mockNextPageHandler).toHaveBeenCalled()
   })
 
   it('navigates to next page using the button when scroll is not available', () => {


### PR DESCRIPTION
added a flag to keep previous data so client can define whether it wants to handle the state of data within the table or externally i.e. in the parent component

also added maxHeight and maxWidth props so the dimensions of the table can also be handled externally
