### PR TITLE
Remove superfluous type from question block

### DIFF
--- a/components/clinical/questionnaire/src/molecules/question-block.tsx
+++ b/components/clinical/questionnaire/src/molecules/question-block.tsx
@@ -40,7 +40,7 @@ const DisplayBlock = styled.div`
 `
 
 const generateAnswer = (
-  type?: QuestionTypes,
+  type?: QuestionnaireItemTypeCode,
   responseItem?: Maybe<QuestionnaireResponseItem>,
   showIfEmpty?: Maybe<boolean>,
   question?: Maybe<string>
@@ -171,22 +171,10 @@ interface IAnswer {
 
 interface IProps {
   className?: string
-  type?: QuestionTypes
+  type?: QuestionnaireItemTypeCode
   question?: Maybe<string>
   responseItem?: Maybe<QuestionnaireResponseItem>
   showIfEmpty?: Maybe<boolean>
 }
-
-type QuestionTypes =
-  | QuestionnaireItemTypeCode.Display
-  | QuestionnaireItemTypeCode.Group
-  | QuestionnaireItemTypeCode.QuestionBoolean
-  | QuestionnaireItemTypeCode.QuestionDate
-  | QuestionnaireItemTypeCode.QuestionString
-  | QuestionnaireItemTypeCode.QuestionStringBbCode
-  | QuestionnaireItemTypeCode.QuestionStringHtml
-  | QuestionnaireItemTypeCode.QuestionCoding
-  | QuestionnaireItemTypeCode.QuestionChoice
-  | QuestionnaireItemTypeCode.Unknown
 
 export default QuestionBlock


### PR DESCRIPTION
This type was just duplicating the GraphQL question type. Not used anywhere and I keep forgetting to update it so removing it.