### PR TITLE
Pass patient id when recording care plan progress

### DIFF
--- a/packages/types/src/atoms/graphql-types.ts
+++ b/packages/types/src/atoms/graphql-types.ts
@@ -1359,6 +1359,7 @@ export type EhrMutationDiscontinueCarePlanArgs = {
 /** Mutations of the LTHT EHR. */
 export type EhrMutationDocumentCarePlanArgs = {
   document: CarePlanDocumentInput;
+  patientGuid: CarePlanDocumentInput;
 };
 
 


### PR DESCRIPTION
Patient identifier is required for authorization flow in API