### PR TITLE
Change type for patient id to GuidGraphType

### DIFF
--- a/packages/types/src/atoms/graphql-types.ts
+++ b/packages/types/src/atoms/graphql-types.ts
@@ -1359,7 +1359,7 @@ export type EhrMutationDiscontinueCarePlanArgs = {
 /** Mutations of the LTHT EHR. */
 export type EhrMutationDocumentCarePlanArgs = {
   document: CarePlanDocumentInput;
-  patientGuid: CarePlanDocumentInput;
+  patientGuid: Scalars['Guid'];
 };
 
 


### PR DESCRIPTION
Accidentally set it to a custom GraphQL model, should just have been a guid