### PR TITLE
Document care plan mutation should be able to return multiple paramters

### DIFF
--- a/packages/types/src/atoms/graphql-types.ts
+++ b/packages/types/src/atoms/graphql-types.ts
@@ -2389,7 +2389,7 @@ export type Parameters = {
   id: Scalars['ID'];
   /** Metadata about the resource. */
   metadata: Metadata;
-  parameter?: Maybe<Parameter>;
+  parameter?: Maybe<Array<Maybe<Parameter>>>;
 };
 
 /** A Date + Time, Year, Year + Month, or just a Time. */


### PR DESCRIPTION
Mistakenly only listed a single parameter as response type, should have been a list. Correcting in this PR