### PR TITLE
Make button more accessible

### DIFF
--- a/components/styled/button/src/atoms/button.tsx
+++ b/components/styled/button/src/atoms/button.tsx
@@ -131,8 +131,6 @@ const ButtonIcon = styled.div<ButtonIconProps>`
   }
 `
 
-const ButtonText = styled.div``
-
 const Button: FC<Props> = ({
   type,
   value,
@@ -141,6 +139,7 @@ const Button: FC<Props> = ({
   icon,
   iconPlacement = 'left',
   iconColour = 'white',
+  children,
   ...rest
 }) => (
   <StyledButton type={type} buttonStyle={buttonStyle} disabled={disabled} {...rest}>
@@ -149,7 +148,8 @@ const Button: FC<Props> = ({
         {icon}
       </ButtonIcon>
     )}
-    {value && <ButtonText>{value}</ButtonText>}
+    {value}
+    {children}
     {icon && iconPlacement === 'right' && (
       <ButtonIcon placement={iconPlacement} iconColour={iconColour}>
         {icon}

--- a/components/styled/button/src/atoms/index.tsx
+++ b/components/styled/button/src/atoms/index.tsx
@@ -1,2 +1,0 @@
-export { default as Button } from './button'
-export { default as PrimaryButton } from './primary-button'

--- a/components/styled/button/src/index.tsx
+++ b/components/styled/button/src/index.tsx
@@ -1,1 +1,2 @@
-export * from './atoms'
+export { default as Button } from './atoms/button'
+export { default as PrimaryButton } from './atoms/button'

--- a/components/styled/menu/src/molecules/action-menu.tsx
+++ b/components/styled/menu/src/molecules/action-menu.tsx
@@ -119,13 +119,7 @@ const ActionMenu: FC<IProps> = ({
             />
           )}
           {menuButtonOptions.type === 'button' && (
-            <Button
-              {...menuButtonOptions.buttonProps}
-              {...rest}
-              value={menuButtonOptions.text}
-              onClick={menuButtonClickHandler}
-              id={id}
-            >
+            <Button {...menuButtonOptions.buttonProps} {...rest} onClick={menuButtonClickHandler} id={id}>
               {menuButtonOptions.text}
             </Button>
           )}

--- a/packages/storybook/src/ui/atoms/buttons/buttons.test.tsx
+++ b/packages/storybook/src/ui/atoms/buttons/buttons.test.tsx
@@ -1,0 +1,33 @@
+import { Button } from '@ltht-react/button'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+describe('Buttons', () => {
+  it('Is findable by role in the accessibility tree', () => {
+    render(<Button type="button">Some Mock Text</Button>)
+
+    expect(screen.getByRole('button', { name: /Some Mock Text/ })).toBeVisible()
+  })
+
+  it('Still spreads the value prop down as children for backwards compatibility', () => {
+    render(<Button type="button" value="Some Mock Text" />)
+
+    expect(screen.getByRole('button', { name: /Some Mock Text/ })).toBeVisible()
+  })
+
+  it('Extends the behaviour of a normal HTML Button', () => {
+    const mockOnClick = jest.fn()
+
+    render(
+      <Button type="button" onClick={mockOnClick} id="123abc">
+        Some Mock Text
+      </Button>
+    )
+
+    expect(screen.getByRole('button')).toHaveAttribute('id', '123abc')
+
+    userEvent.click(screen.getByRole('button'))
+
+    expect(mockOnClick).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
We've added an artificial `value` property to our button element, and render this property as text within an entirely pointless `div` tag. This prevents buttons from being findable in the accessibility tree in the way you'd expect, i.e. `getByRole('button', { name: /some text/ })` 

There are many more re-factors I wanna do on this button but for now I'm preserving the `value` option for backwards compatibility, whilst allowing people to enter text in the children as you would normally. 

For more info on why this is a good change see 
https://testing-library.com/docs/queries/byrole/
and https://www.tpgi.com/what-is-an-accessible-name/