### PR TITLE
Add mutation to complete a care plan

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+# Auto generated files
+packages/types/src/atoms/graphql-types.ts
+**/*.d.ts

--- a/packages/types/src/atoms/graphql-types.ts
+++ b/packages/types/src/atoms/graphql-types.ts
@@ -1,53 +1,53 @@
-export type Maybe<T> = T | null
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] }
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> }
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> }
+export type Maybe<T> = T | null;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string
-  String: string
-  Boolean: boolean
-  Int: number
-  Float: number
-  Date: string
-  DateTimeOffset: string
-  Decimal: number
-  Guid: any
-}
+  ID: string;
+  String: string;
+  Boolean: boolean;
+  Int: number;
+  Float: number;
+  Date: string;
+  DateTimeOffset: string;
+  Decimal: number;
+  Guid: any;
+};
 
 /** An address expressed using postal conventions (as opposed to GPS or other location definition formats). This data type may be used to convey addresses for use in delivering mail as well as for visiting locations which might not be valid for mail delivery. There are a variety of postal address formats defined around the world. */
 export type Address = {
   /** Name of city, town etc. */
-  city?: Maybe<Scalars['String']>
+  city?: Maybe<Scalars['String']>;
   /** Country (e.g. can be ISO 3166 2 or 3 letter code). */
-  country?: Maybe<Scalars['String']>
+  country?: Maybe<Scalars['String']>;
   /** District name (aka county). */
-  district?: Maybe<Scalars['String']>
+  district?: Maybe<Scalars['String']>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Street name, number, direction & P.O. Box etc. This repeating element order: The order in which lines should appear in an address label. */
-  line?: Maybe<Array<Maybe<Scalars['String']>>>
+  line?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Time period when address was/is in use. */
-  period?: Maybe<Period>
+  period?: Maybe<Period>;
   /** Postal code for area. */
-  postalCode?: Maybe<Scalars['String']>
+  postalCode?: Maybe<Scalars['String']>;
   /** Sub-unit of country (abbreviations ok). */
-  state?: Maybe<Scalars['String']>
+  state?: Maybe<Scalars['String']>;
   /** Text representation of the address. */
-  text?: Maybe<Scalars['String']>
+  text?: Maybe<Scalars['String']>;
   /** http://hl7.org/fhir/stu3/valueset-address-type.html */
-  type?: Maybe<AddressTypeCode>
+  type?: Maybe<AddressTypeCode>;
   /** http://hl7.org/fhir/stu3/valueset-address-use.html */
-  use?: Maybe<AddressUseCode>
-}
+  use?: Maybe<AddressUseCode>;
+};
 
 /** http://hl7.org/fhir/stu3/valueset-address-type.html */
 export enum AddressTypeCode {
   Both = 'BOTH',
   Physical = 'PHYSICAL',
-  Postal = 'POSTAL',
+  Postal = 'POSTAL'
 }
 
 /** http://hl7.org/fhir/stu3/valueset-address-use.html */
@@ -55,7 +55,7 @@ export enum AddressUseCode {
   Home = 'HOME',
   Old = 'OLD',
   Temp = 'TEMP',
-  Work = 'WORK',
+  Work = 'WORK'
 }
 
 /** https://fhir.hl7.org.uk/STU3/ValueSet/CareConnect-AdministrativeGender-1l */
@@ -63,210 +63,210 @@ export enum AdministrativeGenderCode {
   Female = 'FEMALE',
   Male = 'MALE',
   Other = 'OTHER',
-  Unknown = 'UNKNOWN',
+  Unknown = 'UNKNOWN'
 }
 
 /** Risk of harmful or undesirable, physiological response which is unique to an individual and associated with exposure to a substance. */
 export type AllergyIntolerance = {
   /** Date record was believed accurate. */
-  assertedDate?: Maybe<PartialDateTime>
+  assertedDate?: Maybe<PartialDateTime>;
   /** Source of the information about the allergy. */
-  asserter?: Maybe<ResourceReference>
+  asserter?: Maybe<ResourceReference>;
   /** http://hl7.org/fhir/stu3/valueset-allergy-intolerance-category.html */
-  category?: Maybe<Array<Maybe<AllergyIntoleranceCategoryCode>>>
+  category?: Maybe<Array<Maybe<AllergyIntoleranceCategoryCode>>>;
   /** http://hl7.org/fhir/stu3/valueset-allergy-clinical-status.html */
-  clinicalStatus?: Maybe<AllergyIntoleranceClinicalStatusCode>
+  clinicalStatus?: Maybe<AllergyIntoleranceClinicalStatusCode>;
   /** http://hl7.org/fhir/stu3/valueset-allergyintolerance-code.html */
-  code?: Maybe<CodeableConcept>
+  code?: Maybe<CodeableConcept>;
   /** http://hl7.org/fhir/stu3/valueset-allergy-intolerance-criticality.html */
-  criticality?: Maybe<AllergyIntoleranceCriticalityCode>
+  criticality?: Maybe<AllergyIntoleranceCriticalityCode>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Logical Id of the resource. */
-  id: Scalars['ID']
+  id: Scalars['ID'];
   /** Business identifiers. */
-  identifier?: Maybe<Array<Maybe<Identifier>>>
+  identifier?: Maybe<Array<Maybe<Identifier>>>;
   /** Flag to state whether the resource should be displayed as entered in error in user interface */
-  isEnteredInError?: Maybe<Scalars['Boolean']>
+  isEnteredInError?: Maybe<Scalars['Boolean']>;
   /** Date(/time) of last known occurrence of a reaction. */
-  lastOccurrence?: Maybe<PartialDateTime>
+  lastOccurrence?: Maybe<PartialDateTime>;
   /** Metadata about the resource. */
-  metadata: Metadata
+  metadata: Metadata;
   /** Additional text not captured in other fields. */
-  note?: Maybe<Array<Maybe<Annotation>>>
+  note?: Maybe<Array<Maybe<Annotation>>>;
   /** When allergy or intolerance was identified. */
-  onSet?: Maybe<AllergyIntoleranceOnSet>
+  onSet?: Maybe<AllergyIntoleranceOnSet>;
   /** Adverse Reaction Events linked to exposure to substance. */
-  reaction?: Maybe<Array<Maybe<AllergyIntoleranceReaction>>>
+  reaction?: Maybe<Array<Maybe<AllergyIntoleranceReaction>>>;
   /** Who recorded the sensitivity. */
-  recorder?: Maybe<ResourceReference>
+  recorder?: Maybe<ResourceReference>;
   /** Text summary of the resource, for human interpretation. */
-  text?: Maybe<Narrative>
+  text?: Maybe<Narrative>;
   /** http://hl7.org/fhir/stu3/valueset-allergy-intolerance-type.html */
-  type?: Maybe<AllergyIntoleranceTypeCode>
+  type?: Maybe<AllergyIntoleranceTypeCode>;
   /** https://fhir.hl7.org.uk/STU3/ValueSet/CareConnect-AllergyVerificationStatus-1 */
-  verificationStatus: AllergyIntoleranceVerificationStatusCode
-}
+  verificationStatus: AllergyIntoleranceVerificationStatusCode;
+};
 
 export enum AllergyIntoleranceCategoryCode {
   Biologic = 'BIOLOGIC',
   Environment = 'ENVIRONMENT',
   Food = 'FOOD',
-  Medication = 'MEDICATION',
+  Medication = 'MEDICATION'
 }
 
 export enum AllergyIntoleranceClinicalStatusCode {
   Active = 'ACTIVE',
   Inactive = 'INACTIVE',
-  Resolved = 'RESOLVED',
+  Resolved = 'RESOLVED'
 }
 
 /** A continuation of Allergy Intolerance resources. */
 export type AllergyIntoleranceContinuationType = {
   /** The first cursor token. */
-  firstCursorToken?: Maybe<Scalars['String']>
+  firstCursorToken?: Maybe<Scalars['String']>;
   /** The next cursor token. */
-  nextCursorToken?: Maybe<Scalars['String']>
+  nextCursorToken?: Maybe<Scalars['String']>;
   /** The continuation of Allergy Intolerance resources. */
-  resources: Array<Maybe<AllergyIntolerance>>
+  resources: Array<Maybe<AllergyIntolerance>>;
   /** The self cursor token. */
-  selfCursorToken: Scalars['String']
+  selfCursorToken: Scalars['String'];
   /** The total number of resources available (if known). */
-  totalResources?: Maybe<Scalars['Int']>
-}
+  totalResources?: Maybe<Scalars['Int']>;
+};
 
 export enum AllergyIntoleranceCriticalityCode {
   High = 'HIGH',
   Low = 'LOW',
-  UnableToAssess = 'UNABLE_TO_ASSESS',
+  UnableToAssess = 'UNABLE_TO_ASSESS'
 }
 
 /** When allergy or intolerance was identified. */
 export type AllergyIntoleranceOnSet = {
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
-  onSetAge?: Maybe<Quantity>
-  onSetDateTime?: Maybe<PartialDateTime>
-  onSetPeriod?: Maybe<Period>
-  onSetRange?: Maybe<Range>
-  onSetString?: Maybe<Scalars['String']>
-}
+  extension?: Maybe<Array<Maybe<Extension>>>;
+  onSetAge?: Maybe<Quantity>;
+  onSetDateTime?: Maybe<PartialDateTime>;
+  onSetPeriod?: Maybe<Period>;
+  onSetRange?: Maybe<Range>;
+  onSetString?: Maybe<Scalars['String']>;
+};
 
 /** Adverse Reaction Events linked to exposure to substance. */
 export type AllergyIntoleranceReaction = {
   /** Description of the event as a whole. */
-  description?: Maybe<Scalars['String']>
+  description?: Maybe<Scalars['String']>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** https://fhir.hl7.org.uk/STU3/ValueSet/CareConnect-AllergyExposureRoute-1 */
-  exposureRoute?: Maybe<CodeableConcept>
+  exposureRoute?: Maybe<CodeableConcept>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** https://fhir.hl7.org.uk/STU3/ValueSet/CareConnect-AllergyManifestation-1 */
-  manifestation: Array<Maybe<CodeableConcept>>
+  manifestation: Array<Maybe<CodeableConcept>>;
   /** Additional text not captured in other fields. */
-  note?: Maybe<Array<Maybe<Annotation>>>
+  note?: Maybe<Array<Maybe<Annotation>>>;
   /** Date(/time) when manifestations showed. */
-  onSet?: Maybe<PartialDateTime>
+  onSet?: Maybe<PartialDateTime>;
   /** https://fhir.hl7.org.uk/STU3/ValueSet/CareConnect-ReactionEventSeverity-1 */
-  severity?: Maybe<AllergyIntoleranceReactionSeverityCode>
+  severity?: Maybe<AllergyIntoleranceReactionSeverityCode>;
   /** http://hl7.org/fhir/stu3/valueset-substance-code.html */
-  substance?: Maybe<CodeableConcept>
-}
+  substance?: Maybe<CodeableConcept>;
+};
 
 export enum AllergyIntoleranceReactionSeverityCode {
   Mild = 'MILD',
   Moderate = 'MODERATE',
-  Severe = 'SEVERE',
+  Severe = 'SEVERE'
 }
 
 export enum AllergyIntoleranceTypeCode {
   Allergy = 'ALLERGY',
-  Intolerance = 'INTOLERANCE',
+  Intolerance = 'INTOLERANCE'
 }
 
 export enum AllergyIntoleranceVerificationStatusCode {
   Confirmed = 'CONFIRMED',
   EnteredInError = 'ENTERED_IN_ERROR',
   Refuted = 'REFUTED',
-  Unconfirmed = 'UNCONFIRMED',
+  Unconfirmed = 'UNCONFIRMED'
 }
 
 /** A text note which also contains information about who made the statement and when. */
 export type Annotation = {
   /** Individual responsible for the annotation. */
-  author?: Maybe<ResourceReference>
+  author?: Maybe<ResourceReference>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** The annotation - text content. */
-  text: Scalars['String']
+  text: Scalars['String'];
   /** When the annotation was made. */
-  time?: Maybe<PartialDateTime>
-}
+  time?: Maybe<PartialDateTime>;
+};
 
 /** Content in a format defined elsewhere. */
 export type Attachment = {
   /** Mime type of the content, with charset etc. */
-  contentType?: Maybe<Scalars['String']>
+  contentType?: Maybe<Scalars['String']>;
   /** Date attachment was first created. */
-  creation?: Maybe<PartialDateTime>
+  creation?: Maybe<PartialDateTime>;
   /** The attachment data. */
-  data?: Maybe<Scalars['String']>
+  data?: Maybe<Scalars['String']>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Hash of the data (sha-1, base64ed). */
-  hash?: Maybe<Scalars['String']>
+  hash?: Maybe<Scalars['String']>;
   /** Human language of the content (BCP-47). */
-  language?: Maybe<Scalars['String']>
+  language?: Maybe<Scalars['String']>;
   /** Number of bytes of content (if url provided). */
-  size?: Maybe<Scalars['Int']>
+  size?: Maybe<Scalars['Int']>;
   /** Label to display in place of the data. */
-  title?: Maybe<Scalars['String']>
+  title?: Maybe<Scalars['String']>;
   /** Uri where the data can be found. */
-  url?: Maybe<Scalars['String']>
-}
+  url?: Maybe<Scalars['String']>;
+};
 
 /** https://www.hl7.org/fhir/R4/auditevent.html */
 export type AuditEvent = {
   /** Type of action performed during the event. */
-  action?: Maybe<AuditEventAction>
+  action?: Maybe<AuditEventAction>;
   /** Type of action performed during the event. */
-  agent: Array<Maybe<AuditEventAgent>>
+  agent: Array<Maybe<AuditEventAgent>>;
   /** Data or objects used. */
-  entity?: Maybe<Array<Maybe<AuditEventEntity>>>
+  entity?: Maybe<Array<Maybe<AuditEventEntity>>>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Logical Id of the resource. */
-  id: Scalars['ID']
+  id: Scalars['ID'];
   /** Flag to state whether the resource should be displayed as entered in error in user interface */
-  isEnteredInError?: Maybe<Scalars['Boolean']>
+  isEnteredInError?: Maybe<Scalars['Boolean']>;
   /** Metadata about the resource. */
-  metadata: Metadata
+  metadata: Metadata;
   /** Whether the event succeeded or failed. */
-  outcome?: Maybe<AuditEventOutcome>
+  outcome?: Maybe<AuditEventOutcome>;
   /** Description of the event outcome. */
-  outcomeDesc?: Maybe<Scalars['String']>
+  outcomeDesc?: Maybe<Scalars['String']>;
   /** When the activity occurred. */
-  period?: Maybe<Period>
+  period?: Maybe<Period>;
   /** The purposeOfUse of the event. */
-  purposeOfEvent?: Maybe<Array<Maybe<CodeableConcept>>>
+  purposeOfEvent?: Maybe<Array<Maybe<CodeableConcept>>>;
   /** Time when the event was recorded. */
-  recorded: PartialDateTime
+  recorded: PartialDateTime;
   /** Audit Event Reporter. */
-  source: AuditEventSource
+  source: AuditEventSource;
   /** More specific type/id for the event. */
-  subType?: Maybe<Array<Maybe<Coding>>>
+  subType?: Maybe<Array<Maybe<Coding>>>;
   /** Text summary of the resource, for human interpretation. */
-  text?: Maybe<Narrative>
+  text?: Maybe<Narrative>;
   /** Type/identifier of event. */
-  type: Coding
-}
+  type: Coding;
+};
 
 export enum AuditEventAction {
   /** C */
@@ -278,263 +278,263 @@ export enum AuditEventAction {
   /** R */
   Read = 'READ',
   /** U */
-  Update = 'UPDATE',
+  Update = 'UPDATE'
 }
 
 /** Actor involved in the event. */
 export type AuditEventAgent = {
   /** Alternative User identity. */
-  altId?: Maybe<Scalars['String']>
+  altId?: Maybe<Scalars['String']>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Where. */
-  location?: Maybe<ResourceReference>
+  location?: Maybe<ResourceReference>;
   /** Type of media. */
-  media?: Maybe<Coding>
+  media?: Maybe<Coding>;
   /** Human friendly name for the agent. */
-  name?: Maybe<Scalars['String']>
+  name?: Maybe<Scalars['String']>;
   /** Logical network location for application activity. */
-  network?: Maybe<AuditEventAgentNetwork>
+  network?: Maybe<AuditEventAgentNetwork>;
   /** Policy that authorized event. */
-  policy?: Maybe<Array<Maybe<Scalars['String']>>>
+  policy?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Reason given for this user. */
-  purposeOfUse?: Maybe<Array<Maybe<CodeableConcept>>>
+  purposeOfUse?: Maybe<Array<Maybe<CodeableConcept>>>;
   /** Whether user is initiator. */
-  requestor: Scalars['Boolean']
+  requestor: Scalars['Boolean'];
   /** Agent role in the event. */
-  role?: Maybe<Array<Maybe<CodeableConcept>>>
+  role?: Maybe<Array<Maybe<CodeableConcept>>>;
   /** How agent participated. */
-  type?: Maybe<CodeableConcept>
+  type?: Maybe<CodeableConcept>;
   /** Identifier of who. */
-  who?: Maybe<ResourceReference>
-}
+  who?: Maybe<ResourceReference>;
+};
 
 /** Logical network location for application activity. */
 export type AuditEventAgentNetwork = {
   /** Identifier for the network access point of the user device. */
-  address?: Maybe<Scalars['String']>
+  address?: Maybe<Scalars['String']>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** The type of network access point. */
-  type?: Maybe<AuditEventAgentNetworkType>
-}
+  type?: Maybe<AuditEventAgentNetworkType>;
+};
 
 export enum AuditEventAgentNetworkType {
   EmailAddress = 'EMAIL_ADDRESS',
   IpAddress = 'IP_ADDRESS',
   MachineName = 'MACHINE_NAME',
   TelephoneNumber = 'TELEPHONE_NUMBER',
-  Uri = 'URI',
+  Uri = 'URI'
 }
 
 /** A continuation of Task resources. */
 export type AuditEventContinuation = {
   /** The first cursor token. */
-  firstCursorToken?: Maybe<Scalars['String']>
+  firstCursorToken?: Maybe<Scalars['String']>;
   /** The next cursor token. */
-  nextCursorToken?: Maybe<Scalars['String']>
+  nextCursorToken?: Maybe<Scalars['String']>;
   /** The continuation of Audit Event resources. */
-  resources: Array<Maybe<AuditEvent>>
+  resources: Array<Maybe<AuditEvent>>;
   /** The self cursor token. */
-  selfCursorToken: Scalars['String']
+  selfCursorToken: Scalars['String'];
   /** The total number of resources available (if known). */
-  totalResources?: Maybe<Scalars['Int']>
-}
+  totalResources?: Maybe<Scalars['Int']>;
+};
 
 /** Data or objects used. */
 export type AuditEventEntity = {
   /** Alternative User identity. */
-  description?: Maybe<Scalars['String']>
+  description?: Maybe<Scalars['String']>;
   /** Additional Information about the entity. */
-  detail?: Maybe<Array<Maybe<AuditEventEntityDetail>>>
+  detail?: Maybe<Array<Maybe<AuditEventEntityDetail>>>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Life-cycle stage for the entity. */
-  lifecycle?: Maybe<Coding>
+  lifecycle?: Maybe<Coding>;
   /** Descriptor for entity. */
-  name?: Maybe<Scalars['String']>
+  name?: Maybe<Scalars['String']>;
   /** Query parameters. */
-  query?: Maybe<Scalars['String']>
+  query?: Maybe<Scalars['String']>;
   /** What role the entity played. */
-  role?: Maybe<Coding>
+  role?: Maybe<Coding>;
   /** Security labels on the entity. */
-  securityLabel?: Maybe<Array<Maybe<Coding>>>
+  securityLabel?: Maybe<Array<Maybe<Coding>>>;
   /** Type of entity involved. */
-  type?: Maybe<Coding>
+  type?: Maybe<Coding>;
   /** Specific instance of resource. */
-  what?: Maybe<ResourceReference>
-}
+  what?: Maybe<ResourceReference>;
+};
 
 /** Additional Information about the entity. */
 export type AuditEventEntityDetail = {
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Name of the property. */
-  type?: Maybe<Scalars['String']>
+  type?: Maybe<Scalars['String']>;
   /** Property value. */
-  value?: Maybe<Scalars['String']>
-}
+  value?: Maybe<Scalars['String']>;
+};
 
 export enum AuditEventOutcome {
   MajorFailure = 'MAJOR_FAILURE',
   MinorFailure = 'MINOR_FAILURE',
   SeriousFailure = 'SERIOUS_FAILURE',
-  Success = 'SUCCESS',
+  Success = 'SUCCESS'
 }
 
 /** Audit Event Reporter. */
 export type AuditEventSource = {
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** The identity of source detecting the event. */
-  observer: ResourceReference
+  observer: ResourceReference;
   /** Logical source location within the enterprise. */
-  site?: Maybe<Scalars['String']>
+  site?: Maybe<Scalars['String']>;
   /** The type of source where event originated. */
-  type?: Maybe<Array<Maybe<Coding>>>
-}
+  type?: Maybe<Array<Maybe<Coding>>>;
+};
 
 /** Describes the intention of how one or more practitioners intend to deliver care for a particular patient, group or community for a period of time, possibly limited to care for a specific condition or set of conditions. */
 export type CarePlan = {
   /** Action to occur as part of plan. */
-  activity?: Maybe<Array<Maybe<CarePlanActivity>>>
+  activity?: Maybe<Array<Maybe<CarePlanActivity>>>;
   /** Health issues this plan addresses. */
-  addresses?: Maybe<Array<Maybe<ResourceReference>>>
+  addresses?: Maybe<Array<Maybe<ResourceReference>>>;
   /** Who is responsible for contents of the plan. Note: This is a list type to be backwards compatible with FHIR R4 but should only contain one entry if possible */
-  author?: Maybe<Array<Maybe<ResourceReference>>>
+  author?: Maybe<Array<Maybe<ResourceReference>>>;
   /** Fulfills care plan. */
-  basedOn?: Maybe<Array<Maybe<ResourceReference>>>
+  basedOn?: Maybe<Array<Maybe<ResourceReference>>>;
   /** Who's involved in plan? */
-  careTeam?: Maybe<Array<Maybe<ResourceReference>>>
+  careTeam?: Maybe<Array<Maybe<ResourceReference>>>;
   /** http://hl7.org/fhir/stu3/valueset-care-plan-category.html */
-  category?: Maybe<Array<Maybe<CodeableConcept>>>
+  category?: Maybe<Array<Maybe<CodeableConcept>>>;
   /** Who provided the content of the care plan */
-  contributor?: Maybe<Array<Maybe<ResourceReference>>>
+  contributor?: Maybe<Array<Maybe<ResourceReference>>>;
   /** Date record was first recorded */
-  created?: Maybe<PartialDateTime>
+  created?: Maybe<PartialDateTime>;
   /** Summary of nature of plan. */
-  description?: Maybe<Scalars['String']>
+  description?: Maybe<Scalars['String']>;
   /** Encounter created as part of. */
-  encounter?: Maybe<ResourceReference>
+  encounter?: Maybe<ResourceReference>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Desired outcome of plan. */
-  goal?: Maybe<Array<Maybe<ResourceReference>>>
+  goal?: Maybe<Array<Maybe<ResourceReference>>>;
   /** Logical Id of the resource. */
-  id: Scalars['ID']
+  id: Scalars['ID'];
   /** Business identifiers. */
-  identifier?: Maybe<Array<Maybe<Identifier>>>
+  identifier?: Maybe<Array<Maybe<Identifier>>>;
   /** Instantiates FHIR protocol or definition. */
-  instantiatesCanonical?: Maybe<Array<Maybe<Scalars['String']>>>
+  instantiatesCanonical?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Instantiates external protocol or definition. */
-  instantiatesUri?: Maybe<Array<Maybe<Scalars['String']>>>
+  instantiatesUri?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** http://hl7.org/fhir/stu3/valueset-care-plan-intent.html */
-  intent: CarePlanIntentCode
+  intent: CarePlanIntentCode;
   /** Flag to state whether the resource should be displayed as entered in error in user interface */
-  isEnteredInError?: Maybe<Scalars['Boolean']>
+  isEnteredInError?: Maybe<Scalars['Boolean']>;
   /** Metadata about the resource. */
-  metadata: Metadata
+  metadata: Metadata;
   /** Comments about the plan. */
-  note?: Maybe<Array<Maybe<Annotation>>>
+  note?: Maybe<Array<Maybe<Annotation>>>;
   /** Part of referenced CarePlan. */
-  partOf?: Maybe<Array<Maybe<ResourceReference>>>
+  partOf?: Maybe<Array<Maybe<ResourceReference>>>;
   /** Time period plan covers. */
-  period?: Maybe<Period>
+  period?: Maybe<Period>;
   /** CarePlan replaced by this CarePlan. */
-  replaces?: Maybe<Array<Maybe<ResourceReference>>>
+  replaces?: Maybe<Array<Maybe<ResourceReference>>>;
   /** http://hl7.org/fhir/stu3/valueset-care-plan-status.html */
-  status: CarePlanStatusCode
+  status: CarePlanStatusCode;
   /** Information considered as part of plan. */
-  supportingInfo?: Maybe<Array<Maybe<ResourceReference>>>
+  supportingInfo?: Maybe<Array<Maybe<ResourceReference>>>;
   /** Text summary of the resource, for human interpretation. */
-  text?: Maybe<Narrative>
+  text?: Maybe<Narrative>;
   /** Human-friendly name for the CarePlan. */
-  title?: Maybe<Scalars['String']>
-}
+  title?: Maybe<Scalars['String']>;
+};
 
 export type CarePlanActionInput = {
-  id?: Maybe<Scalars['String']>
-  label?: Maybe<Scalars['String']>
-  reasonCode?: Maybe<Scalars['String']>
-  reasonText?: Maybe<Scalars['String']>
-  type?: Maybe<Scalars['String']>
-}
+  id?: Maybe<Scalars['String']>;
+  label?: Maybe<Scalars['String']>;
+  reasonCode?: Maybe<Scalars['String']>;
+  reasonText?: Maybe<Scalars['String']>;
+  type?: Maybe<Scalars['String']>;
+};
 
 export type CarePlanActionsInput = {
-  actions?: Maybe<Array<Maybe<CarePlanActionInput>>>
-  planDefinitionId?: Maybe<Scalars['Guid']>
-  planDefinitionLabel?: Maybe<Scalars['String']>
-  reasonCode?: Maybe<Scalars['String']>
-  reasonText?: Maybe<Scalars['String']>
-}
+  actions?: Maybe<Array<Maybe<CarePlanActionInput>>>;
+  planDefinitionId?: Maybe<Scalars['Guid']>;
+  planDefinitionLabel?: Maybe<Scalars['String']>;
+  reasonCode?: Maybe<Scalars['String']>;
+  reasonText?: Maybe<Scalars['String']>;
+};
 
 /** Action to occur as part of plan. */
 export type CarePlanActivity = {
   /** In-line definition of activity. */
-  detail?: Maybe<CarePlanActivityDetail>
+  detail?: Maybe<CarePlanActivityDetail>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** http://hl7.org/fhir/stu3/valueset-care-plan-activity-outcome.html */
-  outcomeCodeableConcept?: Maybe<Array<Maybe<CodeableConcept>>>
+  outcomeCodeableConcept?: Maybe<Array<Maybe<CodeableConcept>>>;
   /** Appointment, Encounter, Procedure, etc. */
-  outcomeReference?: Maybe<Array<Maybe<ResourceReference>>>
+  outcomeReference?: Maybe<Array<Maybe<ResourceReference>>>;
   /** Comments about the activity status/progress. */
-  progress?: Maybe<Array<Maybe<Annotation>>>
+  progress?: Maybe<Array<Maybe<Annotation>>>;
   /** Activity details defined in specific resource. */
-  reference?: Maybe<ResourceReference>
-}
+  reference?: Maybe<ResourceReference>;
+};
 
 /** In-line definition of activity. */
 export type CarePlanActivityDetail = {
   /** http://hl7.org/fhir/stu3/valueset-care-plan-activity.html */
-  code?: Maybe<CodeableConcept>
+  code?: Maybe<CodeableConcept>;
   /** How to consume/day? */
-  dailyAmount?: Maybe<Quantity>
+  dailyAmount?: Maybe<Quantity>;
   /** Extra info describing activity to perform. */
-  description?: Maybe<Scalars['String']>
+  description?: Maybe<Scalars['String']>;
   /** If true, activity is prohibiting action. */
-  doNotPerform?: Maybe<Scalars['Boolean']>
+  doNotPerform?: Maybe<Scalars['Boolean']>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Goals this activity relates to. */
-  goal?: Maybe<Array<Maybe<ResourceReference>>>
+  goal?: Maybe<Array<Maybe<ResourceReference>>>;
   /** Instantiates FHIR protocol or definition. */
-  instantiatesCanonical?: Maybe<Array<Maybe<Scalars['String']>>>
+  instantiatesCanonical?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Instantiates external protocol or definition. */
-  instantiatesUri?: Maybe<Array<Maybe<Scalars['String']>>>
+  instantiatesUri?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** http://hl7.org/fhir/stu3/valueset-care-plan-activity-category.html */
-  kind?: Maybe<CarePlanActivityDetailKindCode>
+  kind?: Maybe<CarePlanActivityDetailKindCode>;
   /** Where it should happen. */
-  location?: Maybe<ResourceReference>
+  location?: Maybe<ResourceReference>;
   /** Who will be responsible? */
-  performer?: Maybe<Array<Maybe<ResourceReference>>>
+  performer?: Maybe<Array<Maybe<ResourceReference>>>;
   /** What is to be administered/supplied. */
-  product?: Maybe<CarePlanActivityDetailProduct>
+  product?: Maybe<CarePlanActivityDetailProduct>;
   /** How much to administer/supply/consume. */
-  quantity?: Maybe<Quantity>
+  quantity?: Maybe<Quantity>;
   /** http://hl7.org/fhir/stu3/valueset-activity-reason.html */
-  reasonCode?: Maybe<Array<Maybe<CodeableConcept>>>
+  reasonCode?: Maybe<Array<Maybe<CodeableConcept>>>;
   /** Condition triggering need for activity. */
-  reasonReference?: Maybe<Array<Maybe<ResourceReference>>>
+  reasonReference?: Maybe<Array<Maybe<ResourceReference>>>;
   /** http://hl7.org/fhir/stu3/valueset-care-plan-activity-status.html */
-  status: CarePlanActivityDetailStatusCode
+  status: CarePlanActivityDetailStatusCode;
   /** Reason for current status. */
-  statusReason?: Maybe<CodeableConcept>
-}
+  statusReason?: Maybe<CodeableConcept>;
+};
 
 export enum CarePlanActivityDetailKindCode {
   Appointment = 'APPOINTMENT',
@@ -544,20 +544,20 @@ export enum CarePlanActivityDetailKindCode {
   NutritionOrder = 'NUTRITION_ORDER',
   ServiceRequest = 'SERVICE_REQUEST',
   Task = 'TASK',
-  VisionPrescription = 'VISION_PRESCRIPTION',
+  VisionPrescription = 'VISION_PRESCRIPTION'
 }
 
 /** What is to be administered/supplied. */
 export type CarePlanActivityDetailProduct = {
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** What is to be administered/supplied. */
-  productCodeableConcept?: Maybe<CodeableConcept>
+  productCodeableConcept?: Maybe<CodeableConcept>;
   /** What is to be administered/supplied. */
-  productReference?: Maybe<ResourceReference>
-}
+  productReference?: Maybe<ResourceReference>;
+};
 
 export enum CarePlanActivityDetailStatusCode {
   Cancelled = 'CANCELLED',
@@ -568,52 +568,52 @@ export enum CarePlanActivityDetailStatusCode {
   OnHold = 'ON_HOLD',
   Scheduled = 'SCHEDULED',
   Stopped = 'STOPPED',
-  Unknown = 'UNKNOWN',
+  Unknown = 'UNKNOWN'
 }
 
 /** A continuation of Care Plan resources. */
 export type CarePlanContinuationType = {
   /** The first cursor token. */
-  firstCursorToken?: Maybe<Scalars['String']>
+  firstCursorToken?: Maybe<Scalars['String']>;
   /** The next cursor token. */
-  nextCursorToken?: Maybe<Scalars['String']>
+  nextCursorToken?: Maybe<Scalars['String']>;
   /** The continuation of Care Plan resources. */
-  resources: Array<Maybe<CarePlan>>
+  resources: Array<Maybe<CarePlan>>;
   /** The self cursor token. */
-  selfCursorToken: Scalars['String']
+  selfCursorToken: Scalars['String'];
   /** The total number of resources available (if known). */
-  totalResources?: Maybe<Scalars['Int']>
-}
+  totalResources?: Maybe<Scalars['Int']>;
+};
 
 /** Record progress against a care plan through interventions and goals */
 export type CarePlanDocumentInput = {
-  carePlanId?: Maybe<Scalars['Guid']>
-  interventions?: Maybe<Array<Maybe<CarePlanInterventionInput>>>
-}
+  carePlanId?: Maybe<Scalars['Guid']>;
+  interventions?: Maybe<Array<Maybe<CarePlanInterventionInput>>>;
+};
 
 export enum CarePlanIntentCode {
   Option = 'OPTION',
   Order = 'ORDER',
   Plan = 'PLAN',
-  Proposal = 'PROPOSAL',
+  Proposal = 'PROPOSAL'
 }
 
 /** Actions taken as part of the intervention */
 export type CarePlanInterventionActionInput = {
-  id?: Maybe<Scalars['String']>
-  label?: Maybe<Scalars['String']>
-}
+  id?: Maybe<Scalars['String']>;
+  label?: Maybe<Scalars['String']>;
+};
 
 /** Interventions performed from the care plan */
 export type CarePlanInterventionInput = {
-  actionDate?: Maybe<Scalars['DateTimeOffset']>
-  actions?: Maybe<Array<Maybe<CarePlanInterventionActionInput>>>
+  actionDate?: Maybe<Scalars['DateTimeOffset']>;
+  actions?: Maybe<Array<Maybe<CarePlanInterventionActionInput>>>;
   /** Provide a unique identifier so you can find the outcome in the response object */
-  id?: Maybe<Scalars['Guid']>
-  interventionId?: Maybe<Scalars['String']>
-  label?: Maybe<Scalars['String']>
-  notes?: Maybe<Scalars['String']>
-}
+  id?: Maybe<Scalars['Guid']>;
+  interventionId?: Maybe<Scalars['String']>;
+  label?: Maybe<Scalars['String']>;
+  notes?: Maybe<Scalars['String']>;
+};
 
 export enum CarePlanStatusCode {
   Active = 'ACTIVE',
@@ -622,187 +622,187 @@ export enum CarePlanStatusCode {
   EnteredInError = 'ENTERED_IN_ERROR',
   OnHold = 'ON_HOLD',
   Revoked = 'REVOKED',
-  Unknown = 'UNKNOWN',
+  Unknown = 'UNKNOWN'
 }
 
 /** A reference to one or more terminologies or ontologies but may also be defined by the provision of text. */
 export type CodeableConcept = {
   /** Code defined by a terminology system. */
-  coding?: Maybe<Array<Maybe<Coding>>>
+  coding?: Maybe<Array<Maybe<Coding>>>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Symbol in syntax defined by the system. */
-  text?: Maybe<Scalars['String']>
-}
+  text?: Maybe<Scalars['String']>;
+};
 
 /** A reference to one or more terminologies or ontologies but may also be defined by the provision of text. */
 export type CodeableConceptInput = {
   /** Code defined by a terminology system. */
-  coding?: Maybe<Array<Maybe<CodingInput>>>
+  coding?: Maybe<Array<Maybe<CodingInput>>>;
   /** Symbol in syntax defined by the system. */
-  text?: Maybe<Scalars['String']>
-}
+  text?: Maybe<Scalars['String']>;
+};
 
 /** A defined concept using a symbol from a code system. */
 export type Coding = {
   /** Symbol in syntax defined by the system. */
-  code?: Maybe<Scalars['String']>
+  code?: Maybe<Scalars['String']>;
   /** Representation defined by the system. */
-  display?: Maybe<Scalars['String']>
+  display?: Maybe<Scalars['String']>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Identity of the terminology system. */
-  system?: Maybe<Scalars['String']>
+  system?: Maybe<Scalars['String']>;
   /** Version of the system - if relevant. */
-  version?: Maybe<Scalars['String']>
-}
+  version?: Maybe<Scalars['String']>;
+};
 
 /** A defined concept using a symbol from a code system. */
 export type CodingInput = {
   /** Symbol in syntax defined by the system. */
-  code?: Maybe<Scalars['String']>
+  code?: Maybe<Scalars['String']>;
   /** Representation defined by the system. */
-  display?: Maybe<Scalars['String']>
+  display?: Maybe<Scalars['String']>;
   /** Identity of the terminology system. */
-  system?: Maybe<Scalars['String']>
+  system?: Maybe<Scalars['String']>;
   /** Version of the system - if relevant. */
-  version?: Maybe<Scalars['String']>
-}
+  version?: Maybe<Scalars['String']>;
+};
 
 export type Condition = {
-  abatement?: Maybe<ConditionAbatement>
-  assertedDate?: Maybe<PartialDateTime>
-  asserter?: Maybe<ConditionAsserter>
-  bodySite?: Maybe<Array<Maybe<CodeableConcept>>>
-  category?: Maybe<Array<Maybe<CodeableConcept>>>
-  clinicalStatus?: Maybe<ConditionClinicalStatus>
-  code?: Maybe<CodeableConcept>
-  context?: Maybe<ResourceReference>
-  evidence?: Maybe<Array<Maybe<ConditionEvidence>>>
+  abatement?: Maybe<ConditionAbatement>;
+  assertedDate?: Maybe<PartialDateTime>;
+  asserter?: Maybe<ConditionAsserter>;
+  bodySite?: Maybe<Array<Maybe<CodeableConcept>>>;
+  category?: Maybe<Array<Maybe<CodeableConcept>>>;
+  clinicalStatus?: Maybe<ConditionClinicalStatus>;
+  code?: Maybe<CodeableConcept>;
+  context?: Maybe<ResourceReference>;
+  evidence?: Maybe<Array<Maybe<ConditionEvidence>>>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
-  extensionData?: Maybe<Array<Maybe<QuestionnaireResponse>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
+  extensionData?: Maybe<Array<Maybe<QuestionnaireResponse>>>;
   /** Logical Id of the resource. */
-  id: Scalars['ID']
-  identifier?: Maybe<Array<Maybe<Identifier>>>
+  id: Scalars['ID'];
+  identifier?: Maybe<Array<Maybe<Identifier>>>;
   /** Flag to state whether the resource should be displayed as entered in error in user interface */
-  isEnteredInError?: Maybe<Scalars['Boolean']>
+  isEnteredInError?: Maybe<Scalars['Boolean']>;
   /** Metadata about the resource. */
-  metadata: Metadata
-  note?: Maybe<Array<Maybe<Annotation>>>
-  onset?: Maybe<ConditionOnset>
-  severity?: Maybe<CodeableConcept>
-  stage?: Maybe<ConditionStage>
+  metadata: Metadata;
+  note?: Maybe<Array<Maybe<Annotation>>>;
+  onset?: Maybe<ConditionOnset>;
+  severity?: Maybe<CodeableConcept>;
+  stage?: Maybe<ConditionStage>;
   /** Text summary of the resource, for human interpretation. */
-  text?: Maybe<Narrative>
-  verificationStatus?: Maybe<ConditionVerificationStatus>
-}
+  text?: Maybe<Narrative>;
+  verificationStatus?: Maybe<ConditionVerificationStatus>;
+};
 
 export type ConditionAbatement = {
-  age?: Maybe<Quantity>
-  dateTime: PartialDateTime
+  age?: Maybe<Quantity>;
+  dateTime: PartialDateTime;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
-  period: Period
-}
+  extension?: Maybe<Array<Maybe<Extension>>>;
+  period: Period;
+};
 
 export enum ConditionAdmissionPeriodType {
   All = 'ALL',
   Current = 'CURRENT',
-  Past = 'PAST',
+  Past = 'PAST'
 }
 
 export type ConditionAsserter = {
-  asserterName?: Maybe<Scalars['String']>
-  asserterType?: Maybe<Scalars['String']>
+  asserterName?: Maybe<Scalars['String']>;
+  asserterType?: Maybe<Scalars['String']>;
   /** Text alternative for the resource. */
-  display: Scalars['String']
+  display: Scalars['String'];
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Business identifier for the referenced resource. */
-  identifier?: Maybe<Identifier>
+  identifier?: Maybe<Identifier>;
   /** Literal reference, Relative, internal or absolute URL. */
-  reference?: Maybe<Scalars['String']>
+  reference?: Maybe<Scalars['String']>;
   /** Type the reference refers to (e.g. Patient. */
-  typeName: Scalars['String']
-}
+  typeName: Scalars['String'];
+};
 
 export enum ConditionClinicalStatus {
   Active = 'ACTIVE',
   Inactive = 'INACTIVE',
   Recurrence = 'RECURRENCE',
   Remission = 'REMISSION',
-  Resolved = 'RESOLVED',
+  Resolved = 'RESOLVED'
 }
 
 /** A continuation of Condition resources. */
 export type ConditionContinuation = {
   /** The first cursor token. */
-  firstCursorToken?: Maybe<Scalars['String']>
+  firstCursorToken?: Maybe<Scalars['String']>;
   /** The next cursor token. */
-  nextCursorToken?: Maybe<Scalars['String']>
+  nextCursorToken?: Maybe<Scalars['String']>;
   /** The continuation of Condition resources. */
-  resources: Array<Maybe<Condition>>
+  resources: Array<Maybe<Condition>>;
   /** The self cursor token. */
-  selfCursorToken: Scalars['String']
+  selfCursorToken: Scalars['String'];
   /** The total number of resources available (if known). */
-  totalResources?: Maybe<Scalars['Int']>
-}
+  totalResources?: Maybe<Scalars['Int']>;
+};
 
 export type ConditionEvidence = {
-  code?: Maybe<Array<Maybe<CodeableConcept>>>
-  detail?: Maybe<Array<Maybe<ResourceReference>>>
+  code?: Maybe<Array<Maybe<CodeableConcept>>>;
+  detail?: Maybe<Array<Maybe<ResourceReference>>>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
-}
+  extension?: Maybe<Array<Maybe<Extension>>>;
+};
 
 export type ConditionMinimalInput = {
-  clinicalStatus?: Maybe<ConditionClinicalStatus>
-  code: CodeableConceptInput
-  extension?: Maybe<Array<Maybe<ExtensionInput>>>
-  id: Scalars['String']
-  onset?: Maybe<ConditionOnsetMinimalInput>
-  verificationStatus?: Maybe<ConditionVerificationStatus>
-}
+  clinicalStatus?: Maybe<ConditionClinicalStatus>;
+  code: CodeableConceptInput;
+  extension?: Maybe<Array<Maybe<ExtensionInput>>>;
+  id: Scalars['String'];
+  onset?: Maybe<ConditionOnsetMinimalInput>;
+  verificationStatus?: Maybe<ConditionVerificationStatus>;
+};
 
 export type ConditionMinimalInputList = {
-  resources: Array<Maybe<ConditionMinimalInput>>
-}
+  resources: Array<Maybe<ConditionMinimalInput>>;
+};
 
 export type ConditionOnset = {
-  age?: Maybe<Quantity>
-  dateTime?: Maybe<PartialDateTime>
+  age?: Maybe<Quantity>;
+  dateTime?: Maybe<PartialDateTime>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
-  period?: Maybe<Period>
-  range?: Maybe<Range>
-  string?: Maybe<Scalars['String']>
-}
+  extension?: Maybe<Array<Maybe<Extension>>>;
+  period?: Maybe<Period>;
+  range?: Maybe<Range>;
+  string?: Maybe<Scalars['String']>;
+};
 
 export type ConditionOnsetMinimalInput = {
-  dateTime: PartialDateTimeInput
-}
+  dateTime: PartialDateTimeInput;
+};
 
 export type ConditionStage = {
-  assessment?: Maybe<Array<Maybe<ResourceReference>>>
+  assessment?: Maybe<Array<Maybe<ResourceReference>>>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
-  summary?: Maybe<CodeableConcept>
-}
+  extension?: Maybe<Array<Maybe<Extension>>>;
+  summary?: Maybe<CodeableConcept>;
+};
 
 export enum ConditionVerificationStatus {
   Confirmed = 'CONFIRMED',
@@ -810,38 +810,38 @@ export enum ConditionVerificationStatus {
   EnteredInError = 'ENTERED_IN_ERROR',
   Provisional = 'PROVISIONAL',
   Refuted = 'REFUTED',
-  Unknown = 'UNKNOWN',
+  Unknown = 'UNKNOWN'
 }
 
 /** The ContactDetail structure defines general contact details. */
 export type ContactDetail = {
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Name of an individual to contact. */
-  name?: Maybe<Scalars['String']>
+  name?: Maybe<Scalars['String']>;
   /** Contact details for individual or organization. */
-  telecom?: Maybe<Array<Maybe<ContactPoint>>>
-}
+  telecom?: Maybe<Array<Maybe<ContactPoint>>>;
+};
 
 /** Details for all kinds of technology-mediated contact points for a person or organization, including telephone, email, etc. */
 export type ContactPoint = {
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Time period when name was/is in use. */
-  period?: Maybe<Period>
+  period?: Maybe<Period>;
   /** Specify preferred order of use (1 = highest). */
-  rank?: Maybe<Scalars['Int']>
+  rank?: Maybe<Scalars['Int']>;
   /** http://hl7.org/fhir/stu3/valueset-contact-point-system.html */
-  system?: Maybe<ContactPointSystemCode>
+  system?: Maybe<ContactPointSystemCode>;
   /** http://hl7.org/fhir/stu3/valueset-contact-point-use.html */
-  use?: Maybe<ContactPointUseCode>
+  use?: Maybe<ContactPointUseCode>;
   /** The actual contact point details. */
-  value?: Maybe<Scalars['String']>
-}
+  value?: Maybe<Scalars['String']>;
+};
 
 /** http://hl7.org/fhir/stu3/valueset-contact-point-system.html */
 export enum ContactPointSystemCode {
@@ -851,7 +851,7 @@ export enum ContactPointSystemCode {
   Pager = 'PAGER',
   Phone = 'PHONE',
   Sms = 'SMS',
-  Url = 'URL',
+  Url = 'URL'
 }
 
 /** http://hl7.org/fhir/stu3/valueset-contact-point-use.html */
@@ -860,24 +860,24 @@ export enum ContactPointUseCode {
   Mobile = 'MOBILE',
   Old = 'OLD',
   Temp = 'TEMP',
-  Work = 'WORK',
+  Work = 'WORK'
 }
 
 /** Provides information on the availability of data from a given Provider for the current User. */
 export type DataAvailability = {
   /** The sources of the available data. */
-  dataSources?: Maybe<Array<Maybe<Coding>>>
+  dataSources?: Maybe<Array<Maybe<Coding>>>;
   /** Logical Id of the resource. */
-  id: Scalars['ID']
+  id: Scalars['ID'];
   /** Metadata about the resource. */
-  metadata: Metadata
-}
+  metadata: Metadata;
+};
 
 export enum DataProviderPermission {
   Ehr = 'EHR',
   GpConnect = 'GP_CONNECT',
   Lypft = 'LYPFT',
-  Yhcr = 'YHCR',
+  Yhcr = 'YHCR'
 }
 
 /** The data source profile to apply to the query context. */
@@ -885,8 +885,10 @@ export enum DataSourceProfile {
   /** The default profile. */
   Default = 'DEFAULT',
   /** Only include Leeds data for testing our own data provision. */
-  LeedsTesting = 'LEEDS_TESTING',
+  LeedsTesting = 'LEEDS_TESTING'
 }
+
+
 
 export enum DaysOfWeekType {
   /** Friday */
@@ -902,638 +904,679 @@ export enum DaysOfWeekType {
   /** Tuesday */
   Tue = 'TUE',
   /** Wednesday */
-  Wed = 'WED',
+  Wed = 'WED'
 }
+
 
 /** The DocumentReference resource is used to describe a document that is made available to a healthcare system. */
 export type DocumentReference = {
   /** Who/what authenticated the document. */
-  authenticator?: Maybe<ResourceReference>
+  authenticator?: Maybe<ResourceReference>;
   /** Who and/or what authored the document. */
-  author?: Maybe<Array<Maybe<DocumentReferenceAuthor>>>
+  author?: Maybe<Array<Maybe<DocumentReferenceAuthor>>>;
   /** http://hl7.org/fhir/stu3/valueset-c80-doc-classcodes.html */
-  class?: Maybe<CodeableConcept>
+  class?: Maybe<CodeableConcept>;
   /** Document referenced. */
-  content: Array<Maybe<DocumentReferenceContent>>
+  content: Array<Maybe<DocumentReferenceContent>>;
   /** Clinical context of document. */
-  context?: Maybe<DocumentReferenceContext>
+  context?: Maybe<DocumentReferenceContext>;
   /** Document creation time. */
-  created?: Maybe<PartialDateTime>
+  created?: Maybe<PartialDateTime>;
   /** Organization which maintains the document. */
-  custodian?: Maybe<ResourceReference>
+  custodian?: Maybe<ResourceReference>;
   /** Human-readable description (title). */
-  description?: Maybe<Scalars['String']>
+  description?: Maybe<Scalars['String']>;
   /** http://hl7.org/fhir/stu3/valueset-composition-status.html */
-  docStatus?: Maybe<DocumentReferenceDocStatusCode>
+  docStatus?: Maybe<DocumentReferenceDocStatusCode>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Logical Id of the resource. */
-  id: Scalars['ID']
+  id: Scalars['ID'];
   /** Business identifiers. */
-  identifier?: Maybe<Array<Maybe<Identifier>>>
+  identifier?: Maybe<Array<Maybe<Identifier>>>;
   /** When this document reference was created. */
-  indexed: PartialDateTime
+  indexed: PartialDateTime;
   /** Flag to state whether the resource should be displayed as entered in error in user interface */
-  isEnteredInError?: Maybe<Scalars['Boolean']>
+  isEnteredInError?: Maybe<Scalars['Boolean']>;
   /** Master Version Specific Identifier. */
-  masterIdentifier?: Maybe<Identifier>
+  masterIdentifier?: Maybe<Identifier>;
   /** Metadata about the resource. */
-  metadata: Metadata
+  metadata: Metadata;
   /** Relationships to other documents. */
-  relatesTo?: Maybe<Array<Maybe<DocumentReferenceRelatesTo>>>
+  relatesTo?: Maybe<Array<Maybe<DocumentReferenceRelatesTo>>>;
   /** Document security-tags. */
-  securityLabel?: Maybe<Array<Maybe<ResourceReference>>>
+  securityLabel?: Maybe<Array<Maybe<ResourceReference>>>;
   /** http://hl7.org/fhir/stu3/valueset-document-reference-status.html */
-  status: DocumentReferenceStatusCode
+  status: DocumentReferenceStatusCode;
   /** Text summary of the resource, for human interpretation. */
-  text?: Maybe<Narrative>
+  text?: Maybe<Narrative>;
   /** https://fhir.hl7.org.uk/STU3/ValueSet/CareConnect-DocumentType-1 */
-  type: CodeableConcept
-}
+  type: CodeableConcept;
+};
 
 export type DocumentReferenceAuthor = {
   /** Text alternative for the resource. */
-  display: Scalars['String']
+  display: Scalars['String'];
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** The author's full name */
-  fullName: Scalars['String']
+  fullName: Scalars['String'];
   /** Business identifier for the referenced resource. */
-  identifier?: Maybe<Identifier>
+  identifier?: Maybe<Identifier>;
   /** Literal reference, Relative, internal or absolute URL. */
-  reference?: Maybe<Scalars['String']>
+  reference?: Maybe<Scalars['String']>;
   /** The author's specialty (e.g. Oncologist, AHP,..) */
-  specialty?: Maybe<Scalars['String']>
+  specialty?: Maybe<Scalars['String']>;
   /** Type the reference refers to (e.g. Patient. */
-  typeName: Scalars['String']
+  typeName: Scalars['String'];
   /** The author's username within the system */
-  username: Scalars['String']
-}
+  username: Scalars['String'];
+};
 
 /** Document referenced. */
 export type DocumentReferenceContent = {
   /** Where to access the document. */
-  attachment: Attachment
+  attachment: Attachment;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Format/content rules for the document. */
-  format?: Maybe<Coding>
-}
+  format?: Maybe<Coding>;
+};
 
 /** Clinical context of document. */
 export type DocumentReferenceContext = {
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Context of the document content. */
-  encounter?: Maybe<DocumentReference>
+  encounter?: Maybe<DocumentReference>;
   /** Main clinical acts documented. */
-  event?: Maybe<Array<Maybe<CodeableConcept>>>
+  event?: Maybe<Array<Maybe<CodeableConcept>>>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Kind of facility where patient was seen. */
-  facilityType?: Maybe<CodeableConcept>
+  facilityType?: Maybe<CodeableConcept>;
   /** Time of service that is being documented. */
-  period?: Maybe<Period>
+  period?: Maybe<Period>;
   /** Additional details about where the content was created (e.g. clinical specialty). */
-  practiceSetting?: Maybe<CodeableConcept>
+  practiceSetting?: Maybe<CodeableConcept>;
   /** Related identifiers or resources. */
-  related?: Maybe<Array<Maybe<DocumentReferenceRelated>>>
+  related?: Maybe<Array<Maybe<DocumentReferenceRelated>>>;
   /** Patient demographics from source. */
-  sourcePatientInfo?: Maybe<DocumentReference>
-}
+  sourcePatientInfo?: Maybe<DocumentReference>;
+};
 
 /** A continuation of DocumentReference resources. */
 export type DocumentReferenceContinuation = {
   /** The first cursor token. */
-  firstCursorToken?: Maybe<Scalars['String']>
+  firstCursorToken?: Maybe<Scalars['String']>;
   /** The next cursor token. */
-  nextCursorToken?: Maybe<Scalars['String']>
+  nextCursorToken?: Maybe<Scalars['String']>;
   /** The continuation of DocumentReference resources. */
-  resources: Array<Maybe<DocumentReference>>
+  resources: Array<Maybe<DocumentReference>>;
   /** The self cursor token. */
-  selfCursorToken: Scalars['String']
+  selfCursorToken: Scalars['String'];
   /** The total number of resources available (if known). */
-  totalResources?: Maybe<Scalars['Int']>
-}
+  totalResources?: Maybe<Scalars['Int']>;
+};
 
 export enum DocumentReferenceDocStatusCode {
   Amended = 'AMENDED',
   Appended = 'APPENDED',
   EnteredInError = 'ENTERED_IN_ERROR',
   Final = 'FINAL',
-  Preliminary = 'PRELIMINARY',
+  Preliminary = 'PRELIMINARY'
 }
 
 /** Related identifiers or resources. */
 export type DocumentReferenceRelated = {
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Identifier of related objects or events. */
-  identifier?: Maybe<Identifier>
+  identifier?: Maybe<Identifier>;
   /** Related Resource. */
-  ref?: Maybe<ResourceReference>
-}
+  ref?: Maybe<ResourceReference>;
+};
 
 /** Relationships to other documents. */
 export type DocumentReferenceRelatesTo = {
   /** http://hl7.org/fhir/stu3/valueset-document-relationship-type.html */
-  code: DocumentReferenceRelatesToCode
+  code: DocumentReferenceRelatesToCode;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Target of the relationship. */
-  target: ResourceReference
-}
+  target: ResourceReference;
+};
 
 export enum DocumentReferenceRelatesToCode {
   Appends = 'APPENDS',
   Replaces = 'REPLACES',
   Signs = 'SIGNS',
-  Transforms = 'TRANSFORMS',
+  Transforms = 'TRANSFORMS'
 }
 
 export enum DocumentReferenceStatusCode {
   Current = 'CURRENT',
   EnteredInError = 'ENTERED_IN_ERROR',
-  Superseded = 'SUPERSEDED',
+  Superseded = 'SUPERSEDED'
 }
 
 export enum DosageRelationshipType {
   And = 'AND',
   Or = 'OR',
   Singleline = 'SINGLELINE',
-  Then = 'THEN',
+  Then = 'THEN'
 }
 
 export type DosageType = {
-  additionalInstruction?: Maybe<Array<Maybe<CodeableConcept>>>
-  asNeededBoolean?: Maybe<Scalars['Boolean']>
-  asNeededCodeableConcept?: Maybe<CodeableConcept>
-  doseQuantity?: Maybe<Quantity>
-  doseRange?: Maybe<Range>
+  additionalInstruction?: Maybe<Array<Maybe<CodeableConcept>>>;
+  asNeededBoolean?: Maybe<Scalars['Boolean']>;
+  asNeededCodeableConcept?: Maybe<CodeableConcept>;
+  doseQuantity?: Maybe<Quantity>;
+  doseRange?: Maybe<Range>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
-  maxDosePerAdministration?: Maybe<Quantity>
-  maxDosePerPeriod?: Maybe<Range>
-  method?: Maybe<CodeableConcept>
-  patientInstruction?: Maybe<Scalars['String']>
-  rateQuantity?: Maybe<Quantity>
-  rateRange?: Maybe<Range>
-  rateRatio?: Maybe<Ratio>
-  route?: Maybe<CodeableConcept>
-  sequence?: Maybe<Scalars['Int']>
-  site?: Maybe<CodeableConcept>
-  text?: Maybe<Scalars['String']>
-  timing?: Maybe<TimingType>
-}
+  extension?: Maybe<Array<Maybe<Extension>>>;
+  maxDosePerAdministration?: Maybe<Quantity>;
+  maxDosePerPeriod?: Maybe<Range>;
+  method?: Maybe<CodeableConcept>;
+  patientInstruction?: Maybe<Scalars['String']>;
+  rateQuantity?: Maybe<Quantity>;
+  rateRange?: Maybe<Range>;
+  rateRatio?: Maybe<Ratio>;
+  route?: Maybe<CodeableConcept>;
+  sequence?: Maybe<Scalars['Int']>;
+  site?: Maybe<CodeableConcept>;
+  text?: Maybe<Scalars['String']>;
+  timing?: Maybe<TimingType>;
+};
 
 /** Queries the LTHT EHR. */
 export type Ehr = {
-  activeCarePlans?: Maybe<CarePlanContinuationType>
-  allergyIntolerance?: Maybe<AllergyIntolerance>
-  allergyIntolerances?: Maybe<AllergyIntoleranceContinuationType>
-  auditEvents?: Maybe<AuditEventContinuation>
-  availableCarePlanDefinitionsForPatient?: Maybe<PlanDefinitionContinuationType>
-  carePlanDefinition?: Maybe<PlanDefinition>
-  carePlanDefinitionUseContexts?: Maybe<Array<Maybe<TerminologyItem>>>
-  carePlanDefinitions?: Maybe<PlanDefinitionContinuationType>
-  condition?: Maybe<Condition>
-  conditions?: Maybe<ConditionContinuation>
-  documentReferences?: Maybe<DocumentReferenceContinuation>
-  guidance?: Maybe<Array<Maybe<Guidance>>>
-  medication?: Maybe<MedicationRequest>
-  medications?: Maybe<MedicationRequestContinuationType>
-  patient?: Maybe<Patient>
-  questionnaireResponseByInstance?: Maybe<QuestionnaireResponse>
-  questionnaireResponseLastCompleted?: Maybe<QuestionnaireResponse>
-  questionnaireResponsesBySet?: Maybe<QuestionnaireResponseContinuation>
-  summaryDefinition?: Maybe<Questionnaire>
-  summaryView?: Maybe<QuestionnaireResponseContinuation>
-  tasks?: Maybe<TaskContinuation>
-  terminologyItems?: Maybe<TerminologyItemContinuation>
-}
+  activeCarePlans?: Maybe<CarePlanContinuationType>;
+  allergyIntolerance?: Maybe<AllergyIntolerance>;
+  allergyIntolerances?: Maybe<AllergyIntoleranceContinuationType>;
+  auditEvents?: Maybe<AuditEventContinuation>;
+  availableCarePlanDefinitionsForPatient?: Maybe<PlanDefinitionContinuationType>;
+  carePlanDefinition?: Maybe<PlanDefinition>;
+  carePlanDefinitionUseContexts?: Maybe<Array<Maybe<TerminologyItem>>>;
+  carePlanDefinitions?: Maybe<PlanDefinitionContinuationType>;
+  condition?: Maybe<Condition>;
+  conditions?: Maybe<ConditionContinuation>;
+  documentReferences?: Maybe<DocumentReferenceContinuation>;
+  guidance?: Maybe<Array<Maybe<Guidance>>>;
+  medication?: Maybe<MedicationRequest>;
+  medications?: Maybe<MedicationRequestContinuationType>;
+  patient?: Maybe<Patient>;
+  questionnaireResponseByInstance?: Maybe<QuestionnaireResponse>;
+  questionnaireResponseLastCompleted?: Maybe<QuestionnaireResponse>;
+  questionnaireResponsesBySet?: Maybe<QuestionnaireResponseContinuation>;
+  summaryDefinition?: Maybe<Questionnaire>;
+  summaryView?: Maybe<QuestionnaireResponseContinuation>;
+  tasks?: Maybe<TaskContinuation>;
+  terminologyItems?: Maybe<TerminologyItemContinuation>;
+};
+
 
 /** Queries the LTHT EHR. */
 export type EhrActiveCarePlansArgs = {
-  count?: Maybe<Scalars['Int']>
-  cursorToken?: Maybe<Scalars['String']>
-  pathwayType: Scalars['String']
-  patientGuid: Scalars['String']
-}
+  count?: Maybe<Scalars['Int']>;
+  cursorToken?: Maybe<Scalars['String']>;
+  pathwayType: Scalars['String'];
+  patientGuid: Scalars['String'];
+};
+
 
 /** Queries the LTHT EHR. */
 export type EhrAllergyIntoleranceArgs = {
-  id: Scalars['String']
-  patientGuid: Scalars['String']
-}
+  id: Scalars['String'];
+  patientGuid: Scalars['String'];
+};
+
 
 /** Queries the LTHT EHR. */
 export type EhrAllergyIntolerancesArgs = {
-  clinicalStatus?: Maybe<Array<Maybe<AllergyIntoleranceClinicalStatusCode>>>
-  count?: Maybe<Scalars['Int']>
-  cursorToken?: Maybe<Scalars['String']>
-  fhirVersion: Scalars['String']
-  listScope?: Maybe<Scalars['String']>
-  listType: Scalars['String']
-  patientGuid: Scalars['String']
-}
+  clinicalStatus?: Maybe<Array<Maybe<AllergyIntoleranceClinicalStatusCode>>>;
+  count?: Maybe<Scalars['Int']>;
+  cursorToken?: Maybe<Scalars['String']>;
+  fhirVersion: Scalars['String'];
+  listScope?: Maybe<Scalars['String']>;
+  listType: Scalars['String'];
+  patientGuid: Scalars['String'];
+};
+
 
 /** Queries the LTHT EHR. */
 export type EhrAuditEventsArgs = {
-  auditProfile?: Maybe<Scalars['String']>
-  count?: Maybe<Scalars['Int']>
-  cursorToken?: Maybe<Scalars['String']>
-  pathwayId: Scalars['String']
-  pathwayType: Scalars['String']
-  patientGuid: Scalars['String']
-}
+  auditProfile?: Maybe<Scalars['String']>;
+  count?: Maybe<Scalars['Int']>;
+  cursorToken?: Maybe<Scalars['String']>;
+  pathwayId: Scalars['String'];
+  pathwayType: Scalars['String'];
+  patientGuid: Scalars['String'];
+};
+
 
 /** Queries the LTHT EHR. */
 export type EhrAvailableCarePlanDefinitionsForPatientArgs = {
-  count?: Maybe<Scalars['Int']>
-  cursorToken?: Maybe<Scalars['String']>
-  filter?: Maybe<Scalars['String']>
-  pathwayType: Scalars['String']
-  patientGuid?: Maybe<Scalars['Guid']>
-  useContext?: Maybe<Scalars['String']>
-}
+  count?: Maybe<Scalars['Int']>;
+  cursorToken?: Maybe<Scalars['String']>;
+  filter?: Maybe<Scalars['String']>;
+  pathwayType: Scalars['String'];
+  patientGuid?: Maybe<Scalars['Guid']>;
+  useContext?: Maybe<Scalars['String']>;
+};
+
 
 /** Queries the LTHT EHR. */
 export type EhrCarePlanDefinitionArgs = {
-  id: Scalars['String']
-}
+  id: Scalars['String'];
+};
+
 
 /** Queries the LTHT EHR. */
 export type EhrCarePlanDefinitionUseContextsArgs = {
-  pathwayType: Scalars['String']
-}
+  pathwayType: Scalars['String'];
+};
+
 
 /** Queries the LTHT EHR. */
 export type EhrCarePlanDefinitionsArgs = {
-  count?: Maybe<Scalars['Int']>
-  cursorToken?: Maybe<Scalars['String']>
-  filter?: Maybe<Scalars['String']>
-  pathwayType: Scalars['String']
-  useContext?: Maybe<Scalars['String']>
-}
+  count?: Maybe<Scalars['Int']>;
+  cursorToken?: Maybe<Scalars['String']>;
+  filter?: Maybe<Scalars['String']>;
+  pathwayType: Scalars['String'];
+  useContext?: Maybe<Scalars['String']>;
+};
+
 
 /** Queries the LTHT EHR. */
 export type EhrConditionArgs = {
-  id: Scalars['String']
-  patientGuid: Scalars['String']
-}
+  id: Scalars['String'];
+  patientGuid: Scalars['String'];
+};
+
 
 /** Queries the LTHT EHR. */
 export type EhrConditionsArgs = {
-  admissionPeriod?: Maybe<ConditionAdmissionPeriodType>
-  clinicalStatus?: Maybe<Array<Maybe<ConditionClinicalStatus>>>
-  count?: Maybe<Scalars['Int']>
-  cursorToken?: Maybe<Scalars['String']>
-  patientGuid: Scalars['String']
-  severity?: Maybe<Array<Maybe<Scalars['String']>>>
-  sortBy?: Maybe<SortOptionType>
-  verificationStatus?: Maybe<Array<Maybe<ConditionVerificationStatus>>>
-}
+  admissionPeriod?: Maybe<ConditionAdmissionPeriodType>;
+  clinicalStatus?: Maybe<Array<Maybe<ConditionClinicalStatus>>>;
+  count?: Maybe<Scalars['Int']>;
+  cursorToken?: Maybe<Scalars['String']>;
+  patientGuid: Scalars['String'];
+  severity?: Maybe<Array<Maybe<Scalars['String']>>>;
+  sortBy?: Maybe<SortOptionType>;
+  verificationStatus?: Maybe<Array<Maybe<ConditionVerificationStatus>>>;
+};
+
 
 /** Queries the LTHT EHR. */
 export type EhrDocumentReferencesArgs = {
-  patientGuid: Scalars['String']
-  template: Scalars['String']
-}
+  patientGuid: Scalars['String'];
+  template: Scalars['String'];
+};
+
 
 /** Queries the LTHT EHR. */
 export type EhrGuidanceArgs = {
-  instanceSetGuid: Scalars['String']
-  patientGuid: Scalars['String']
-  template: Scalars['String']
-}
+  instanceSetGuid: Scalars['String'];
+  patientGuid: Scalars['String'];
+  template: Scalars['String'];
+};
+
 
 /** Queries the LTHT EHR. */
 export type EhrMedicationArgs = {
-  id: Scalars['String']
-  patientGuid: Scalars['String']
-}
+  id: Scalars['String'];
+  patientGuid: Scalars['String'];
+};
+
 
 /** Queries the LTHT EHR. */
 export type EhrMedicationsArgs = {
-  count?: Maybe<Scalars['Int']>
-  cursorToken?: Maybe<Scalars['String']>
-  fhirVersion: Scalars['String']
-  listScope?: Maybe<Scalars['String']>
-  listType: Scalars['String']
-  patientGuid: Scalars['String']
-}
+  count?: Maybe<Scalars['Int']>;
+  cursorToken?: Maybe<Scalars['String']>;
+  fhirVersion: Scalars['String'];
+  listScope?: Maybe<Scalars['String']>;
+  listType: Scalars['String'];
+  patientGuid: Scalars['String'];
+};
+
 
 /** Queries the LTHT EHR. */
 export type EhrPatientArgs = {
-  patientGuid: Scalars['String']
-}
+  patientGuid: Scalars['String'];
+};
+
 
 /** Queries the LTHT EHR. */
 export type EhrQuestionnaireResponseByInstanceArgs = {
-  instanceGuid: Scalars['String']
-  name: Scalars['String']
-  patientGuid: Scalars['String']
-}
+  instanceGuid: Scalars['String'];
+  name: Scalars['String'];
+  patientGuid: Scalars['String'];
+};
+
 
 /** Queries the LTHT EHR. */
 export type EhrQuestionnaireResponseLastCompletedArgs = {
-  name: Scalars['String']
-  patientGuid: Scalars['String']
-  setGuid: Scalars['String']
-}
+  name: Scalars['String'];
+  patientGuid: Scalars['String'];
+  setGuid: Scalars['String'];
+};
+
 
 /** Queries the LTHT EHR. */
 export type EhrQuestionnaireResponsesBySetArgs = {
-  count?: Maybe<Scalars['Int']>
-  cursorToken?: Maybe<Scalars['String']>
-  patientGuid: Scalars['String']
-  setGuid: Scalars['String']
-  templateName: Scalars['String']
-}
+  count?: Maybe<Scalars['Int']>;
+  cursorToken?: Maybe<Scalars['String']>;
+  patientGuid: Scalars['String'];
+  setGuid: Scalars['String'];
+  templateName: Scalars['String'];
+};
+
 
 /** Queries the LTHT EHR. */
 export type EhrSummaryDefinitionArgs = {
-  name: Scalars['String']
-}
+  name: Scalars['String'];
+};
+
 
 /** Queries the LTHT EHR. */
 export type EhrSummaryViewArgs = {
-  count?: Maybe<Scalars['Int']>
-  cursorToken?: Maybe<Scalars['String']>
-  name: Scalars['String']
-  patientGuid: Scalars['String']
-}
+  count?: Maybe<Scalars['Int']>;
+  cursorToken?: Maybe<Scalars['String']>;
+  name: Scalars['String'];
+  patientGuid: Scalars['String'];
+};
+
 
 /** Queries the LTHT EHR. */
 export type EhrTasksArgs = {
-  count?: Maybe<Scalars['Int']>
-  cursorToken?: Maybe<Scalars['String']>
-  pathwayId?: Maybe<Scalars['String']>
-  pathwayType?: Maybe<Scalars['String']>
-  patientGuid: Scalars['String']
-  status?: Array<Maybe<TaskStatusCode>>
-}
+  count?: Maybe<Scalars['Int']>;
+  cursorToken?: Maybe<Scalars['String']>;
+  pathwayId?: Maybe<Scalars['String']>;
+  pathwayType?: Maybe<Scalars['String']>;
+  patientGuid: Scalars['String'];
+  status?: Array<Maybe<TaskStatusCode>>;
+};
+
 
 /** Queries the LTHT EHR. */
 export type EhrTerminologyItemsArgs = {
-  codeSystem: Scalars['String']
-  codeSystemVersion: Scalars['Int']
-  count?: Maybe<Scalars['Int']>
-  cursorToken?: Maybe<Scalars['String']>
-  filter: Scalars['String']
-}
+  codeSystem: Scalars['String'];
+  codeSystemVersion: Scalars['Int'];
+  count?: Maybe<Scalars['Int']>;
+  cursorToken?: Maybe<Scalars['String']>;
+  filter: Scalars['String'];
+};
 
 /** Mutations of the LTHT EHR. */
 export type EhrMutation = {
-  addCarePlan?: Maybe<CarePlan>
-  addConditions?: Maybe<Array<Maybe<Condition>>>
-  discontinueCarePlan?: Maybe<CarePlan>
-  documentCarePlan?: Maybe<Scalars['Boolean']>
-  pauseCarePlan?: Maybe<CarePlan>
-  resumeCarePlan?: Maybe<CarePlan>
-  setConditionStatus?: Maybe<Condition>
-  updateCarePlan?: Maybe<CarePlan>
-  updateTask?: Maybe<Task>
-}
+  addCarePlan?: Maybe<CarePlan>;
+  addConditions?: Maybe<Array<Maybe<Condition>>>;
+  completeCarePlan?: Maybe<CarePlan>;
+  discontinueCarePlan?: Maybe<CarePlan>;
+  documentCarePlan?: Maybe<Parameters>;
+  pauseCarePlan?: Maybe<CarePlan>;
+  resumeCarePlan?: Maybe<CarePlan>;
+  setConditionStatus?: Maybe<Condition>;
+  updateCarePlan?: Maybe<CarePlan>;
+  updateTask?: Maybe<Task>;
+};
+
 
 /** Mutations of the LTHT EHR. */
 export type EhrMutationAddCarePlanArgs = {
-  model: CarePlanActionsInput
-  patientGuid: Scalars['Guid']
-  template: Scalars['String']
-}
+  model: CarePlanActionsInput;
+  patientGuid: Scalars['Guid'];
+  template: Scalars['String'];
+};
+
 
 /** Mutations of the LTHT EHR. */
 export type EhrMutationAddConditionsArgs = {
-  conditions: ConditionMinimalInputList
-  patientGuid: Scalars['String']
-  template: Scalars['String']
-}
+  conditions: ConditionMinimalInputList;
+  patientGuid: Scalars['String'];
+  template: Scalars['String'];
+};
+
+
+/** Mutations of the LTHT EHR. */
+export type EhrMutationCompleteCarePlanArgs = {
+  carePlanId: Scalars['Guid'];
+  patientGuid: Scalars['Guid'];
+  template: Scalars['String'];
+};
+
 
 /** Mutations of the LTHT EHR. */
 export type EhrMutationDiscontinueCarePlanArgs = {
-  carePlanId: Scalars['Guid']
-  patientGuid: Scalars['Guid']
-  reasonCode: Scalars['String']
-  reasonText: Scalars['String']
-  template: Scalars['String']
-}
+  carePlanId: Scalars['Guid'];
+  patientGuid: Scalars['Guid'];
+  reasonCode: Scalars['String'];
+  reasonText: Scalars['String'];
+  template: Scalars['String'];
+};
+
 
 /** Mutations of the LTHT EHR. */
 export type EhrMutationDocumentCarePlanArgs = {
-  document: CarePlanDocumentInput
-  interventionTemplate: Scalars['String']
-  patientGuid: Scalars['Guid']
-}
+  document: CarePlanDocumentInput;
+  interventionTemplate: Scalars['String'];
+  patientGuid: Scalars['Guid'];
+};
+
 
 /** Mutations of the LTHT EHR. */
 export type EhrMutationPauseCarePlanArgs = {
-  carePlanId: Scalars['Guid']
-  continuationDate?: Maybe<Scalars['DateTimeOffset']>
-  patientGuid: Scalars['Guid']
-  reasonCode: Scalars['String']
-  reasonText: Scalars['String']
-  template?: Maybe<Scalars['String']>
-}
+  carePlanId: Scalars['Guid'];
+  continuationDate?: Maybe<Scalars['DateTimeOffset']>;
+  patientGuid: Scalars['Guid'];
+  reasonCode: Scalars['String'];
+  reasonText: Scalars['String'];
+  template?: Maybe<Scalars['String']>;
+};
+
 
 /** Mutations of the LTHT EHR. */
 export type EhrMutationResumeCarePlanArgs = {
-  carePlanId: Scalars['Guid']
-  patientGuid: Scalars['Guid']
-  template?: Maybe<Scalars['String']>
-}
+  carePlanId: Scalars['Guid'];
+  patientGuid: Scalars['Guid'];
+  template?: Maybe<Scalars['String']>;
+};
+
 
 /** Mutations of the LTHT EHR. */
 export type EhrMutationSetConditionStatusArgs = {
-  clinicalStatus?: Maybe<ConditionClinicalStatus>
-  conditionId: Scalars['String']
-  patientGuid: Scalars['String']
-  template: Scalars['String']
-  verificationStatus?: Maybe<ConditionVerificationStatus>
-}
+  clinicalStatus?: Maybe<ConditionClinicalStatus>;
+  conditionId: Scalars['String'];
+  patientGuid: Scalars['String'];
+  template: Scalars['String'];
+  verificationStatus?: Maybe<ConditionVerificationStatus>;
+};
+
 
 /** Mutations of the LTHT EHR. */
 export type EhrMutationUpdateCarePlanArgs = {
-  carePlanId: Scalars['Guid']
-  model: CarePlanActionsInput
-  patientGuid: Scalars['Guid']
-  template: Scalars['String']
-}
+  carePlanId: Scalars['Guid'];
+  model: CarePlanActionsInput;
+  patientGuid: Scalars['Guid'];
+  template: Scalars['String'];
+};
+
 
 /** Mutations of the LTHT EHR. */
 export type EhrMutationUpdateTaskArgs = {
-  patientGuid: Scalars['String']
-  processId?: Maybe<Scalars['String']>
-  processType?: Maybe<Scalars['String']>
-  taskId?: Maybe<Scalars['String']>
-  taskName?: Maybe<Scalars['String']>
-  taskOutcome?: Maybe<Scalars['String']>
-}
+  patientGuid: Scalars['String'];
+  processId?: Maybe<Scalars['String']>;
+  processType?: Maybe<Scalars['String']>;
+  taskId?: Maybe<Scalars['String']>;
+  taskName?: Maybe<Scalars['String']>;
+  taskOutcome?: Maybe<Scalars['String']>;
+};
 
 /** The encounter resource represents an encounter between a care professional and the patient (or patient's record). */
 export type Encounter = {
   /** The set of accounts that may be used for billing for this Encounter. */
-  account?: Maybe<ResourceReference>
+  account?: Maybe<ResourceReference>;
   /** The appointment that scheduled this encounter. */
-  appointment?: Maybe<ResourceReference>
+  appointment?: Maybe<ResourceReference>;
   /** http://hl7.org/fhir/stu3/v3/ActEncounterCode/vs.html */
-  class?: Maybe<Coding>
+  class?: Maybe<Coding>;
   /** List of past encounter classes. */
-  classHistory?: Maybe<Array<Maybe<EncounterClassHistory>>>
+  classHistory?: Maybe<Array<Maybe<EncounterClassHistory>>>;
   /** The list of diagnosis relevant to this encounter. */
-  diagnosis?: Maybe<Array<Maybe<EncounterDiagnosis>>>
+  diagnosis?: Maybe<Array<Maybe<EncounterDiagnosis>>>;
   /** Episode(s) of care that this encounter should be recorded against. */
-  episodeOfCare?: Maybe<Array<Maybe<ResourceReference>>>
+  episodeOfCare?: Maybe<Array<Maybe<ResourceReference>>>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** AuthDetails about the admission to a healthcare service. */
-  hospitalization?: Maybe<EncounterHospitalisation>
+  hospitalization?: Maybe<EncounterHospitalisation>;
   /** Logical Id of the resource. */
-  id: Scalars['ID']
+  id: Scalars['ID'];
   /** Business identifiers. */
-  identifier?: Maybe<Array<Maybe<Identifier>>>
+  identifier?: Maybe<Array<Maybe<Identifier>>>;
   /** The ReferralRequest that initiated this encounter. */
-  incomingReferral?: Maybe<Array<Maybe<ResourceReference>>>
+  incomingReferral?: Maybe<Array<Maybe<ResourceReference>>>;
   /** Flag to state whether the resource should be displayed as entered in error in user interface */
-  isEnteredInError?: Maybe<Scalars['Boolean']>
+  isEnteredInError?: Maybe<Scalars['Boolean']>;
   /** Quantity of time the encounter lasted (less time absent). */
-  length?: Maybe<Quantity>
+  length?: Maybe<Quantity>;
   /** List of locations where the patient has been. */
-  location?: Maybe<Array<Maybe<EncounterLocation>>>
+  location?: Maybe<Array<Maybe<EncounterLocation>>>;
   /** Metadata about the resource. */
-  metadata: Metadata
+  metadata: Metadata;
   /** Another Encounter this encounter is part of. */
-  partOf?: Maybe<ResourceReference>
+  partOf?: Maybe<ResourceReference>;
   /** http://hl7.org/fhir/stu3/v3/ActPriority/vs.html */
-  participant?: Maybe<Array<Maybe<EncounterParticipant>>>
+  participant?: Maybe<Array<Maybe<EncounterParticipant>>>;
   /** The start and end time of the encounter. */
-  period?: Maybe<Period>
+  period?: Maybe<Period>;
   /** http://hl7.org/fhir/stu3/v3/ActPriority/vs.html */
-  priority?: Maybe<CodeableConcept>
+  priority?: Maybe<CodeableConcept>;
   /** http://hl7.org/fhir/stu3/valueset-encounter-reason.html */
-  reason?: Maybe<Array<Maybe<CodeableConcept>>>
+  reason?: Maybe<Array<Maybe<CodeableConcept>>>;
   /** The custodian organization of this Encounter record. */
-  serviceProvider?: Maybe<ResourceReference>
+  serviceProvider?: Maybe<ResourceReference>;
   /** http://hl7.org/fhir/stu3/valueset-encounter-status.html */
-  status?: Maybe<EncounterStatusCode>
+  status?: Maybe<EncounterStatusCode>;
   /** List of past encounter statuses. */
-  statusHistory?: Maybe<Array<Maybe<EncounterStatusHistory>>>
+  statusHistory?: Maybe<Array<Maybe<EncounterStatusHistory>>>;
   /** Text summary of the resource, for human interpretation. */
-  text?: Maybe<Narrative>
+  text?: Maybe<Narrative>;
   /** http://hl7.org/fhir/stu3/valueset-encounter-type.html */
-  type?: Maybe<Array<Maybe<CodeableConcept>>>
-}
+  type?: Maybe<Array<Maybe<CodeableConcept>>>;
+};
 
 /** List of past encounter classes. */
 export type EncounterClassHistory = {
   /** http://hl7.org/fhir/stu3/v3/ActEncounterCode/vs.html */
-  class: Coding
+  class: Coding;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** The time that the episode was in the specified status. */
-  period: Period
-}
+  period: Period;
+};
 
 /** A continuation of Encounter resources. */
 export type EncounterContinuation = {
   /** The first cursor token. */
-  firstCursorToken?: Maybe<Scalars['String']>
+  firstCursorToken?: Maybe<Scalars['String']>;
   /** The next cursor token. */
-  nextCursorToken?: Maybe<Scalars['String']>
+  nextCursorToken?: Maybe<Scalars['String']>;
   /** The continuation of Encounter resources. */
-  resources: Array<Maybe<Encounter>>
+  resources: Array<Maybe<Encounter>>;
   /** The self cursor token. */
-  selfCursorToken: Scalars['String']
+  selfCursorToken: Scalars['String'];
   /** The total number of resources available (if known). */
-  totalResources?: Maybe<Scalars['Int']>
-}
+  totalResources?: Maybe<Scalars['Int']>;
+};
 
 /** The list of diagnosis relevant to this encounter. */
 export type EncounterDiagnosis = {
   /** Reason the encounter takes place (resource). */
-  condition?: Maybe<ResourceReference>
+  condition?: Maybe<ResourceReference>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Ranking of the diagnosis (for each role type). */
-  rank?: Maybe<Scalars['Int']>
+  rank?: Maybe<Scalars['Int']>;
   /** http://hl7.org/fhir/stu3/valueset-diagnosis-role.html */
-  role?: Maybe<CodeableConcept>
-}
+  role?: Maybe<CodeableConcept>;
+};
 
 /** AuthDetails about the admission to a healthcare service. */
 export type EncounterHospitalisation = {
   /** https://fhir.hl7.org.uk/STU3/ValueSet/CareConnect-SourceOfAdmission-1 */
-  admitSource?: Maybe<CodeableConcept>
+  admitSource?: Maybe<CodeableConcept>;
   /** Location to which the patient is discharged. */
-  destination?: Maybe<ResourceReference>
+  destination?: Maybe<ResourceReference>;
   /** http://hl7.org/fhir/stu3/valueset-encounter-diet.html */
-  dietPreference?: Maybe<Array<Maybe<CodeableConcept>>>
+  dietPreference?: Maybe<Array<Maybe<CodeableConcept>>>;
   /** https://fhir.hl7.org.uk/STU3/ValueSet/CareConnect-DischargeDestination-1 */
-  dischargeDisposition?: Maybe<CodeableConcept>
+  dischargeDisposition?: Maybe<CodeableConcept>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** The location from which the patient came before admission. */
-  origin?: Maybe<ResourceReference>
+  origin?: Maybe<ResourceReference>;
   /** Pre-admission identifier. */
-  preAdmissionIdentifier?: Maybe<Identifier>
+  preAdmissionIdentifier?: Maybe<Identifier>;
   /** http://hl7.org/fhir/stu3/ValueSet/v2-0092 */
-  reAdmission?: Maybe<CodeableConcept>
+  reAdmission?: Maybe<CodeableConcept>;
   /** http://hl7.org/fhir/stu3/valueset-encounter-special-arrangements.html */
-  specialArrangement?: Maybe<Array<Maybe<CodeableConcept>>>
+  specialArrangement?: Maybe<Array<Maybe<CodeableConcept>>>;
   /** http://hl7.org/fhir/stu3/valueset-encounter-special-courtesy.html */
-  specialCourtesy?: Maybe<Array<Maybe<CodeableConcept>>>
-}
+  specialCourtesy?: Maybe<Array<Maybe<CodeableConcept>>>;
+};
 
 /** List of locations where the patient has been. */
 export type EncounterLocation = {
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Location the encounter takes place. */
-  location: ResourceReference
+  location: ResourceReference;
   /** Time period during which the patient was present at the location. */
-  period?: Maybe<Period>
+  period?: Maybe<Period>;
   /** http://hl7.org/fhir/stu3/valueset-encounter-location-status.html */
-  status?: Maybe<EncounterLocationStatusCode>
-}
+  status?: Maybe<EncounterLocationStatusCode>;
+};
 
 export enum EncounterLocationStatusCode {
   Active = 'ACTIVE',
   Completed = 'COMPLETED',
   Planned = 'PLANNED',
-  Reserved = 'RESERVED',
+  Reserved = 'RESERVED'
 }
 
 /** List of participants involved in the encounter. */
 export type EncounterParticipant = {
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Persons involved in the encounter other than the patient. */
-  individual?: Maybe<ResourceReference>
+  individual?: Maybe<ResourceReference>;
   /** Period of time during the encounter that the participant participated. */
-  period?: Maybe<Period>
+  period?: Maybe<Period>;
   /** http://hl7.org/fhir/stu3/valueset-encounter-participant-type.html */
-  type?: Maybe<Array<Maybe<CodeableConcept>>>
-}
+  type?: Maybe<Array<Maybe<CodeableConcept>>>;
+};
 
 export enum EncounterStatusCode {
   Arrived = 'ARRIVED',
@@ -1544,41 +1587,41 @@ export enum EncounterStatusCode {
   OnLeave = 'ON_LEAVE',
   Planned = 'PLANNED',
   Triaged = 'TRIAGED',
-  Unknown = 'UNKNOWN',
+  Unknown = 'UNKNOWN'
 }
 
 /** List of past encounter statuses. */
 export type EncounterStatusHistory = {
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** The time that the episode was in the specified status. */
-  period: Period
+  period: Period;
   /** http://hl7.org/fhir/stu3/valueset-encounter-status.html */
-  status?: Maybe<EncounterStatusCode>
-}
+  status?: Maybe<EncounterStatusCode>;
+};
 
 export enum EntityAction {
   Create = 'CREATE',
   Delete = 'DELETE',
   Read = 'READ',
-  Update = 'UPDATE',
+  Update = 'UPDATE'
 }
 
 /** Permission to perform one or more Operations on a given Entity. */
 export type EntityPermission = {
   /** The Operation(s) the User can perform on the Entity. */
-  actions: Array<EntityAction>
+  actions: Array<EntityAction>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** The Resource the user has access to. */
-  resource?: Maybe<Scalars['String']>
+  resource?: Maybe<Scalars['String']>;
   /** The Entity the user has access to. */
-  type: EntityType
-}
+  type: EntityType;
+};
 
 export enum EntityType {
   Address = 'ADDRESS',
@@ -1617,7 +1660,6 @@ export enum EntityType {
   CustomListSuspiciousFindings = 'CUSTOM_LIST_SUSPICIOUS_FINDINGS',
   Diagnosis = 'DIAGNOSIS',
   Document = 'DOCUMENT',
-  DocumentTimelinePilot = 'DOCUMENT_TIMELINE_PILOT',
   Edan = 'EDAN',
   EdanAdmin = 'EDAN_ADMIN',
   Emeds = 'EMEDS',
@@ -1625,7 +1667,6 @@ export enum EntityType {
   EndOfLifeCare = 'END_OF_LIFE_CARE',
   Epro = 'EPRO',
   FileLink = 'FILE_LINK',
-  FormTimelinePilot = 'FORM_TIMELINE_PILOT',
   Guidance = 'GUIDANCE',
   Helm = 'HELM',
   Hmds = 'HMDS',
@@ -1712,58 +1753,58 @@ export enum EntityType {
   WatchListManagement = 'WATCH_LIST_MANAGEMENT',
   WinDipCaseNotes = 'WIN_DIP_CASE_NOTES',
   WinDipReferalDocuments = 'WIN_DIP_REFERAL_DOCUMENTS',
-  XForms = 'X_FORMS',
+  XForms = 'X_FORMS'
 }
 
 /** An association between a patient and an organization / healthcare provider(s) during which time encounters may occur. The managing organization assumes a level of responsibility for the patient during this time. */
 export type EpisodeOfCare = {
   /** The set of accounts that may be used for billing for this EpisodeOfCare. */
-  account?: Maybe<ResourceReference>
+  account?: Maybe<ResourceReference>;
   /** Care manager/care co-ordinator for the patient. */
-  careManager?: Maybe<ResourceReference>
+  careManager?: Maybe<ResourceReference>;
   /** The list of diagnosis relevant to this episode of care. */
-  diagnosis?: Maybe<Array<Maybe<EpisodeOfCareDiagnosis>>>
+  diagnosis?: Maybe<Array<Maybe<EpisodeOfCareDiagnosis>>>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Logical Id of the resource. */
-  id: Scalars['ID']
+  id: Scalars['ID'];
   /** Business identifiers. */
-  identifier?: Maybe<Array<Maybe<Identifier>>>
+  identifier?: Maybe<Array<Maybe<Identifier>>>;
   /** Flag to state whether the resource should be displayed as entered in error in user interface */
-  isEnteredInError?: Maybe<Scalars['Boolean']>
+  isEnteredInError?: Maybe<Scalars['Boolean']>;
   /** Organization that assumes care. */
-  managingOrganization?: Maybe<ResourceReference>
+  managingOrganization?: Maybe<ResourceReference>;
   /** Metadata about the resource. */
-  metadata: Metadata
+  metadata: Metadata;
   /** Interval during responsibility is assumed. */
-  period?: Maybe<Period>
+  period?: Maybe<Period>;
   /** Originating Referral Request(s). */
-  referralRequest?: Maybe<Array<Maybe<ResourceReference>>>
+  referralRequest?: Maybe<Array<Maybe<ResourceReference>>>;
   /** http://hl7.org/fhir/stu3/valueset-episode-of-care-status.html */
-  status: EpisodeOfCareStatusCode
+  status: EpisodeOfCareStatusCode;
   /** Past list of status codes (the current status may be included to cover the start date of the status). */
-  statusHistory?: Maybe<Array<Maybe<EpisodeOfCareStatusHistory>>>
+  statusHistory?: Maybe<Array<Maybe<EpisodeOfCareStatusHistory>>>;
   /** Other practitioners facilitating this episode of care. */
-  team?: Maybe<Array<Maybe<ResourceReference>>>
+  team?: Maybe<Array<Maybe<ResourceReference>>>;
   /** Text summary of the resource, for human interpretation. */
-  text?: Maybe<Narrative>
+  text?: Maybe<Narrative>;
   /** http://hl7.org/fhir/stu3/valueset-episodeofcare-type.html */
-  type?: Maybe<Array<Maybe<CodeableConcept>>>
-}
+  type?: Maybe<Array<Maybe<CodeableConcept>>>;
+};
 
 /** The list of diagnosis relevant to this episode of care. */
 export type EpisodeOfCareDiagnosis = {
   /** Conditions/problems/diagnoses this episode of care is for. */
-  condition: ResourceReference
+  condition: ResourceReference;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Ranking of the diagnosis (for each role type). */
-  rank?: Maybe<Scalars['Int']>
+  rank?: Maybe<Scalars['Int']>;
   /** http://hl7.org/fhir/stu3/valueset-diagnosis-role.html */
-  role?: Maybe<CodeableConcept>
-}
+  role?: Maybe<CodeableConcept>;
+};
 
 export enum EpisodeOfCareStatusCode {
   Active = 'ACTIVE',
@@ -1772,145 +1813,147 @@ export enum EpisodeOfCareStatusCode {
   Finished = 'FINISHED',
   OnHold = 'ON_HOLD',
   Planned = 'PLANNED',
-  WaitList = 'WAIT_LIST',
+  WaitList = 'WAIT_LIST'
 }
 
 /** Past list of status codes (the current status may be included to cover the start date of the status). */
 export type EpisodeOfCareStatusHistory = {
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Duration the EpisodeOfCare was in the specified status. */
-  period: Period
+  period: Period;
   /** http://hl7.org/fhir/stu3/valueset-episode-of-care-status.html */
-  status: EncounterStatusCode
-}
+  status: EncounterStatusCode;
+};
 
 /** Additional content defined by implementations. */
 export type Extension = {
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Value of extension (String Array). */
-  multiValueString?: Maybe<Array<Maybe<Scalars['String']>>>
+  multiValueString?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Identifies the meaning of the extension. */
-  url: Scalars['String']
+  url: Scalars['String'];
   /** Value of extension (Attachment). */
-  valueAttachment?: Maybe<Attachment>
+  valueAttachment?: Maybe<Attachment>;
   /** Value of extension (Boolean). */
-  valueBoolean?: Maybe<Scalars['Boolean']>
+  valueBoolean?: Maybe<Scalars['Boolean']>;
   /** Value of extension (CodeableConcept). */
-  valueCodeableConcept?: Maybe<CodeableConcept>
+  valueCodeableConcept?: Maybe<CodeableConcept>;
   /** Value of extension (Coding). */
-  valueCoding?: Maybe<Coding>
+  valueCoding?: Maybe<Coding>;
   /** Value of extension (DateTime). */
-  valueDateTime?: Maybe<PartialDateTime>
+  valueDateTime?: Maybe<PartialDateTime>;
   /** Value of extension (Identifier). */
-  valueIdentifier?: Maybe<Identifier>
+  valueIdentifier?: Maybe<Identifier>;
   /** Value of extension (Integer). */
-  valueInteger?: Maybe<Scalars['Int']>
+  valueInteger?: Maybe<Scalars['Int']>;
   /** Value of extension (String). */
-  valueString?: Maybe<Scalars['String']>
+  valueString?: Maybe<Scalars['String']>;
   /** Value of extension (Uuid). */
-  valueUuid?: Maybe<Scalars['Guid']>
-}
+  valueUuid?: Maybe<Scalars['Guid']>;
+};
 
 export type ExtensionInput = {
   /** Identifies the meaning of the extension */
-  url: Scalars['String']
+  url: Scalars['String'];
   /** Boolean value of extension */
-  valueBoolean?: Maybe<Scalars['Boolean']>
-}
+  valueBoolean?: Maybe<Scalars['Boolean']>;
+};
 
 export enum FeatureInstance {
   FormsForHealthLaunch = 'FORMS_FOR_HEALTH_LAUNCH',
   GpConnectDataProvider = 'GP_CONNECT_DATA_PROVIDER',
   InteractWithDiagnosisDashboard = 'INTERACT_WITH_DIAGNOSIS_DASHBOARD',
   ResourceAuthorization = 'RESOURCE_AUTHORIZATION',
-  YhcrDataProvider = 'YHCR_DATA_PROVIDER',
+  YhcrDataProvider = 'YHCR_DATA_PROVIDER'
 }
 
 /** An instance of a feature that is controlled via a toggle. */
 export type FeatureToggle = {
   /** The message to show (if status is message). */
-  disabledMessage?: Maybe<Scalars['String']>
+  disabledMessage?: Maybe<Scalars['String']>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** The feature instance the toggle controls. */
-  featureFlag: FeatureInstance
+  featureFlag: FeatureInstance;
   /** The status of the feature toggle. */
-  isEnabled: Scalars['Boolean']
-}
+  isEnabled: Scalars['Boolean'];
+};
 
 /** Prospective warnings of potential issues when providing care to the patient. */
 export type Flag = {
   /** Flag creator. */
-  author?: Maybe<ResourceReference>
+  author?: Maybe<ResourceReference>;
   /** http://hl7.org/fhir/stu3/valueset-flag-category.html */
-  category?: Maybe<CodeableConcept>
+  category?: Maybe<CodeableConcept>;
   /** http://hl7.org/fhir/stu3/valueset-flag-code.html */
-  code: CodeableConcept
+  code: CodeableConcept;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Logical Id of the resource. */
-  id: Scalars['ID']
+  id: Scalars['ID'];
   /** Business identifiers. */
-  identifier?: Maybe<Array<Maybe<Identifier>>>
+  identifier?: Maybe<Array<Maybe<Identifier>>>;
   /** Flag to state whether the resource should be displayed as entered in error in user interface */
-  isEnteredInError?: Maybe<Scalars['Boolean']>
+  isEnteredInError?: Maybe<Scalars['Boolean']>;
   /** Metadata about the resource. */
-  metadata: Metadata
+  metadata: Metadata;
   /** Time period when flag is active. */
-  period?: Maybe<Period>
+  period?: Maybe<Period>;
   /** http://hl7.org/fhir/stu3/valueset-flag-status.html */
-  status: FlagStatusCode
+  status: FlagStatusCode;
   /** Text summary of the resource, for human interpretation. */
-  text?: Maybe<Narrative>
-}
+  text?: Maybe<Narrative>;
+};
 
 export enum FlagStatusCode {
   Active = 'ACTIVE',
   EnteredInError = 'ENTERED_IN_ERROR',
-  Inactive = 'INACTIVE',
+  Inactive = 'INACTIVE'
 }
 
 /** Queries the GP Connect system. */
 export type GpConnect = {
-  dataAvailability?: Maybe<DataAvailability>
-}
+  dataAvailability?: Maybe<DataAvailability>;
+};
+
 
 /** Queries the GP Connect system. */
 export type GpConnectDataAvailabilityArgs = {
-  nhsNumber: Scalars['String']
-}
+  nhsNumber: Scalars['String'];
+};
+
 
 /** https://hl7.org/fhir/2018May/guidanceresponse.html */
 export type Guidance = {
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Logical Id of the resource. */
-  id: Scalars['ID']
+  id: Scalars['ID'];
   /** Flag to state whether the resource should be displayed as entered in error in user interface */
-  isEnteredInError?: Maybe<Scalars['Boolean']>
+  isEnteredInError?: Maybe<Scalars['Boolean']>;
   /** Metadata about the resource. */
-  metadata: Metadata
+  metadata: Metadata;
   /** The guidance item. */
-  note?: Maybe<Array<Maybe<Annotation>>>
+  note?: Maybe<Array<Maybe<Annotation>>>;
   /** When the guidance response was processed. */
-  occuranceDateTime?: Maybe<PartialDateTime>
+  occuranceDateTime?: Maybe<PartialDateTime>;
   /** Describes the reason for the guidance response in coded or textual form. */
-  reasonCode?: Maybe<CodeableConcept>
+  reasonCode?: Maybe<CodeableConcept>;
   /** The identifier of the request associated with this response, if any. */
-  requestIdentifier?: Maybe<Identifier>
+  requestIdentifier?: Maybe<Identifier>;
   /** http://hl7.org/fhir/ValueSet/guidance-response-status */
-  status: GuidanceStatusCode
+  status: GuidanceStatusCode;
   /** Text summary of the resource, for human interpretation. */
-  text?: Maybe<Narrative>
-}
+  text?: Maybe<Narrative>;
+};
 
 export enum GuidanceStatusCode {
   DataRequested = 'DATA_REQUESTED',
@@ -1918,30 +1961,30 @@ export enum GuidanceStatusCode {
   EnteredInError = 'ENTERED_IN_ERROR',
   Failure = 'FAILURE',
   InProgress = 'IN_PROGRESS',
-  Success = 'SUCCESS',
+  Success = 'SUCCESS'
 }
 
 /** A name of a human with text, parts and usage information. */
 export type HumanName = {
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Family name (often called 'Surname'). */
-  family?: Maybe<Scalars['String']>
+  family?: Maybe<Scalars['String']>;
   /** Given names (not always 'first'). Includes middle names. This repeating element order: Given Names appear in the correct order for presenting the name. */
-  given?: Maybe<Array<Maybe<Scalars['String']>>>
+  given?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Time period when name was/is in use. */
-  period?: Maybe<Period>
+  period?: Maybe<Period>;
   /** Parts that come before the name. This repeating element order: Prefixes appear in the correct order for presenting the name. */
-  prefix?: Maybe<Array<Maybe<Scalars['String']>>>
+  prefix?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Parts that come after the name. This repeating element order: Suffixes appear in the correct order for presenting the name. */
-  suffix?: Maybe<Array<Maybe<Scalars['String']>>>
+  suffix?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Text representation of the full name. */
-  text?: Maybe<Scalars['String']>
+  text?: Maybe<Scalars['String']>;
   /** http://hl7.org/fhir/stu3/valueset-name-use.html */
-  use?: Maybe<HumanNameUseCode>
-}
+  use?: Maybe<HumanNameUseCode>;
+};
 
 /** http://hl7.org/fhir/stu3/valueset-name-use.html */
 export enum HumanNameUseCode {
@@ -1951,191 +1994,200 @@ export enum HumanNameUseCode {
   Official = 'OFFICIAL',
   Old = 'OLD',
   Temp = 'TEMP',
-  Usual = 'USUAL',
+  Usual = 'USUAL'
 }
 
 /** A business identifier associated with a single object or entity within a given system. */
 export type Identifier = {
   /** Organization that issued id (may be just text). */
-  assigner?: Maybe<ResourceReference>
+  assigner?: Maybe<ResourceReference>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Time period when id is/was valid for use. */
-  period?: Maybe<Period>
+  period?: Maybe<Period>;
   /** The namespace for the identifier value. */
-  system?: Maybe<Scalars['String']>
+  system?: Maybe<Scalars['String']>;
   /** http://hl7.org/fhir/stu3/valueset-identifier-type.html */
-  type?: Maybe<CodeableConcept>
+  type?: Maybe<CodeableConcept>;
   /** http://hl7.org/fhir/stu3/valueset-identifier-use.html */
-  use?: Maybe<IdentifierUseCode>
+  use?: Maybe<IdentifierUseCode>;
   /** The value that is unique. */
-  value: Scalars['String']
-}
+  value: Scalars['String'];
+};
 
 export enum IdentifierUseCode {
   Official = 'OFFICIAL',
   Secondary = 'SECONDARY',
   Temp = 'TEMP',
-  Usual = 'USUAL',
+  Usual = 'USUAL'
 }
 
 export enum IntentCode {
   Order = 'ORDER',
   Plan = 'PLAN',
-  Proposal = 'PROPOSAL',
+  Proposal = 'PROPOSAL'
 }
 
 /** Queries the LYPFT EHR. */
 export type Lypft = {
-  allergyIntolerances?: Maybe<Array<Maybe<AllergyIntolerance>>>
-  appointments?: Maybe<EncounterContinuation>
-  carePlans?: Maybe<Array<Maybe<CarePlan>>>
-  careTeams?: Maybe<Array<Maybe<EpisodeOfCare>>>
-  communityTreatmentOrders?: Maybe<Array<Maybe<LypftCommunityTreatmentOrder>>>
-  dataAvailability?: Maybe<DataAvailability>
-  documents?: Maybe<Array<Maybe<DocumentReference>>>
-  flags?: Maybe<Array<Maybe<Flag>>>
-  hospitalStays?: Maybe<Array<Maybe<Encounter>>>
-}
+  allergyIntolerances?: Maybe<Array<Maybe<AllergyIntolerance>>>;
+  appointments?: Maybe<EncounterContinuation>;
+  carePlans?: Maybe<Array<Maybe<CarePlan>>>;
+  careTeams?: Maybe<Array<Maybe<EpisodeOfCare>>>;
+  communityTreatmentOrders?: Maybe<Array<Maybe<LypftCommunityTreatmentOrder>>>;
+  dataAvailability?: Maybe<DataAvailability>;
+  documents?: Maybe<Array<Maybe<DocumentReference>>>;
+  flags?: Maybe<Array<Maybe<Flag>>>;
+  hospitalStays?: Maybe<Array<Maybe<Encounter>>>;
+};
+
 
 /** Queries the LYPFT EHR. */
 export type LypftAllergyIntolerancesArgs = {
-  clinicalStatus?: Maybe<Array<Maybe<AllergyIntoleranceClinicalStatusCode>>>
-  nhsNumber: Scalars['String']
-}
+  clinicalStatus?: Maybe<Array<Maybe<AllergyIntoleranceClinicalStatusCode>>>;
+  nhsNumber: Scalars['String'];
+};
+
 
 /** Queries the LYPFT EHR. */
 export type LypftAppointmentsArgs = {
-  count?: Maybe<Scalars['Int']>
-  cursorToken?: Maybe<Scalars['String']>
-  nhsNumber: Scalars['String']
-  status?: Maybe<Array<Maybe<EncounterStatusCode>>>
-}
+  count?: Maybe<Scalars['Int']>;
+  cursorToken?: Maybe<Scalars['String']>;
+  nhsNumber: Scalars['String'];
+  status?: Maybe<Array<Maybe<EncounterStatusCode>>>;
+};
+
 
 /** Queries the LYPFT EHR. */
 export type LypftCarePlansArgs = {
-  nhsNumber: Scalars['String']
-}
+  nhsNumber: Scalars['String'];
+};
+
 
 /** Queries the LYPFT EHR. */
 export type LypftCareTeamsArgs = {
-  nhsNumber: Scalars['String']
-}
+  nhsNumber: Scalars['String'];
+};
+
 
 /** Queries the LYPFT EHR. */
 export type LypftCommunityTreatmentOrdersArgs = {
-  nhsNumber: Scalars['String']
-}
+  nhsNumber: Scalars['String'];
+};
+
 
 /** Queries the LYPFT EHR. */
 export type LypftDataAvailabilityArgs = {
-  nhsNumber: Scalars['String']
-}
+  nhsNumber: Scalars['String'];
+};
+
 
 /** Queries the LYPFT EHR. */
 export type LypftDocumentsArgs = {
-  nhsNumber: Scalars['String']
-}
+  nhsNumber: Scalars['String'];
+};
+
 
 /** Queries the LYPFT EHR. */
 export type LypftFlagsArgs = {
-  nhsNumber: Scalars['String']
-}
+  nhsNumber: Scalars['String'];
+};
+
 
 /** Queries the LYPFT EHR. */
 export type LypftHospitalStaysArgs = {
-  nhsNumber: Scalars['String']
-}
+  nhsNumber: Scalars['String'];
+};
 
 export enum LaunchApp {
-  FormsForHealth = 'FORMS_FOR_HEALTH',
+  FormsForHealth = 'FORMS_FOR_HEALTH'
 }
 
 /** Permission to launch one or more Apps with the given Intents. */
 export type LaunchPermission = {
   /** The App the user can launch. */
-  application: LaunchApp
+  application: LaunchApp;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** The Intent(s) the user can launch the App with. */
-  intents: Array<Scalars['String']>
+  intents: Array<Scalars['String']>;
   /** The Resource the user wishes to launch. */
-  resource: Scalars['String']
-}
+  resource: Scalars['String'];
+};
 
 /** Community Treatment Order – LYPFT Custom Resource. */
 export type LypftCommunityTreatmentOrder = {
   /** ?Needs more information from LYPFT? */
-  consentToTreat?: Maybe<Scalars['String']>
+  consentToTreat?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Logical Id of the resource. */
-  id: Scalars['ID']
+  id: Scalars['ID'];
   /** Flag to state whether the resource should be displayed as entered in error in user interface */
-  isEnteredInError?: Maybe<Scalars['Boolean']>
+  isEnteredInError?: Maybe<Scalars['Boolean']>;
   /** The legal status of the treatment order. */
-  legalStatus?: Maybe<CodeableConcept>
+  legalStatus?: Maybe<CodeableConcept>;
   /** Metadata about the resource. */
-  metadata: Metadata
+  metadata: Metadata;
   /** The time period of the treatment order. */
-  period: Period
+  period: Period;
   /** ?Needs more information from LYPFT? */
-  restrictions?: Maybe<Scalars['String']>
+  restrictions?: Maybe<Scalars['String']>;
   /** Text summary of the resource, for human interpretation. */
-  text?: Maybe<Narrative>
-}
+  text?: Maybe<Narrative>;
+};
 
 export type MedicationRequest = {
-  authoredOn?: Maybe<PartialDateTime>
-  category?: Maybe<CodeableConcept>
-  context?: Maybe<ResourceReference>
-  dosageInstruction?: Maybe<Array<Maybe<DosageType>>>
-  dosageRelationship?: Maybe<DosageRelationshipType>
+  authoredOn?: Maybe<PartialDateTime>;
+  category?: Maybe<CodeableConcept>;
+  context?: Maybe<ResourceReference>;
+  dosageInstruction?: Maybe<Array<Maybe<DosageType>>>;
+  dosageRelationship?: Maybe<DosageRelationshipType>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Logical Id of the resource. */
-  id: Scalars['ID']
-  identifier?: Maybe<Array<Maybe<Identifier>>>
-  intent?: Maybe<MedicationRequestIntentType>
+  id: Scalars['ID'];
+  identifier?: Maybe<Array<Maybe<Identifier>>>;
+  intent?: Maybe<MedicationRequestIntentType>;
   /** Flag to state whether the resource should be displayed as entered in error in user interface */
-  isEnteredInError?: Maybe<Scalars['Boolean']>
-  medicationReference?: Maybe<MedicationType>
+  isEnteredInError?: Maybe<Scalars['Boolean']>;
+  medicationReference?: Maybe<MedicationType>;
   /** Metadata about the resource. */
-  metadata: Metadata
-  note?: Maybe<Array<Maybe<Annotation>>>
-  priority?: Maybe<MedicationRequestPriorityType>
-  reasonCode?: Maybe<Array<Maybe<CodeableConcept>>>
-  reasonReference?: Maybe<ResourceReference>
-  status?: Maybe<MedicationRequestStatusType>
-  subject?: Maybe<ResourceReference>
-  supportingInformation?: Maybe<Array<Maybe<ResourceReference>>>
+  metadata: Metadata;
+  note?: Maybe<Array<Maybe<Annotation>>>;
+  priority?: Maybe<MedicationRequestPriorityType>;
+  reasonCode?: Maybe<Array<Maybe<CodeableConcept>>>;
+  reasonReference?: Maybe<ResourceReference>;
+  status?: Maybe<MedicationRequestStatusType>;
+  subject?: Maybe<ResourceReference>;
+  supportingInformation?: Maybe<Array<Maybe<ResourceReference>>>;
   /** Text summary of the resource, for human interpretation. */
-  text?: Maybe<Narrative>
-}
+  text?: Maybe<Narrative>;
+};
 
 /** A continuation of Medication Request resources. */
 export type MedicationRequestContinuationType = {
   /** The first cursor token. */
-  firstCursorToken?: Maybe<Scalars['String']>
+  firstCursorToken?: Maybe<Scalars['String']>;
   /** The next cursor token. */
-  nextCursorToken?: Maybe<Scalars['String']>
+  nextCursorToken?: Maybe<Scalars['String']>;
   /** The continuation of Medication Request resources. */
-  resources: Array<Maybe<MedicationRequest>>
+  resources: Array<Maybe<MedicationRequest>>;
   /** The self cursor token. */
-  selfCursorToken: Scalars['String']
+  selfCursorToken: Scalars['String'];
   /** The total number of resources available (if known). */
-  totalResources?: Maybe<Scalars['Int']>
-}
+  totalResources?: Maybe<Scalars['Int']>;
+};
 
 export enum MedicationRequestIntentType {
   InstanceOrder = 'INSTANCE_ORDER',
   Order = 'ORDER',
   Plan = 'PLAN',
-  Proposal = 'PROPOSAL',
+  Proposal = 'PROPOSAL'
 }
 
 export enum MedicationRequestPriorityType {
@@ -2146,7 +2198,7 @@ export enum MedicationRequestPriorityType {
   /** Stat */
   Stat = 'STAT',
   /** Urgent */
-  Urgent = 'URGENT',
+  Urgent = 'URGENT'
 }
 
 export enum MedicationRequestStatusType {
@@ -2157,138 +2209,138 @@ export enum MedicationRequestStatusType {
   EnteredInError = 'ENTERED_IN_ERROR',
   OnHold = 'ON_HOLD',
   Stopped = 'STOPPED',
-  Unknown = 'UNKNOWN',
+  Unknown = 'UNKNOWN'
 }
 
 export type MedicationType = {
-  code?: Maybe<CodeableConcept>
+  code?: Maybe<CodeableConcept>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
-  form?: Maybe<CodeableConcept>
-  isBrand?: Maybe<Scalars['Boolean']>
+  extension?: Maybe<Array<Maybe<Extension>>>;
+  form?: Maybe<CodeableConcept>;
+  isBrand?: Maybe<Scalars['Boolean']>;
   /** Flag to state whether the resource should be displayed as entered in error in user interface */
-  isEnteredInError?: Maybe<Scalars['Boolean']>
+  isEnteredInError?: Maybe<Scalars['Boolean']>;
   /** Text summary of the resource, for human interpretation. */
-  text?: Maybe<Narrative>
-}
+  text?: Maybe<Narrative>;
+};
 
 /** Metadata about the resource. */
 export type Metadata = {
   /** The sources of the resource. */
-  dataSources: Array<Maybe<Coding>>
+  dataSources: Array<Maybe<Coding>>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Has data been redacted for this resource instance? */
-  isRedacted: Scalars['Boolean']
+  isRedacted: Scalars['Boolean'];
   /** When the resource last changed - e.g. when the version changed. */
-  lastUpdated?: Maybe<Scalars['DateTimeOffset']>
+  lastUpdated?: Maybe<Scalars['DateTimeOffset']>;
   /** When the resource was requested. */
-  requestedWhen: Scalars['DateTimeOffset']
+  requestedWhen: Scalars['DateTimeOffset'];
   /** Security tags for this resource instance. */
-  security?: Maybe<Array<Maybe<Coding>>>
+  security?: Maybe<Array<Maybe<Coding>>>;
   /** To identify and relate resources to process and workflow. */
-  tag?: Maybe<Array<Maybe<Coding>>>
+  tag?: Maybe<Array<Maybe<Coding>>>;
   /** The version specific identifier. This value changes when the resource is created, updated, or deleted. */
-  versionId?: Maybe<Scalars['String']>
-}
+  versionId?: Maybe<Scalars['String']>;
+};
 
 export type Mutation = {
-  ehr?: Maybe<EhrMutation>
-}
+  ehr?: Maybe<EhrMutation>;
+};
 
 /** Text summary of the resource, for human interpretation. */
 export type Narrative = {
   /** Limited xhtml content. */
-  div: Scalars['String']
+  div: Scalars['String'];
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** http://hl7.org/fhir/narrative-status */
-  status?: Maybe<NarrativeStatusCode>
+  status?: Maybe<NarrativeStatusCode>;
   /** Parsed text from Div. */
-  text: Scalars['String']
-}
+  text: Scalars['String'];
+};
 
 export enum NarrativeStatusCode {
   Additional = 'ADDITIONAL',
   Empty = 'EMPTY',
   Extensions = 'EXTENSIONS',
-  Generated = 'GENERATED',
+  Generated = 'GENERATED'
 }
 
 /** https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Observation-1 */
 export type Observation = {
-  basedOn?: Maybe<ResourceReference>
-  bodySite?: Maybe<Array<Maybe<CodeableConcept>>>
-  category?: Maybe<Array<Maybe<CodeableConcept>>>
-  code: CodeableConcept
-  comment?: Maybe<Scalars['String']>
-  component?: Maybe<Array<Maybe<ObservationComponent>>>
-  context?: Maybe<ResourceReference>
-  dataAbsentReason?: Maybe<CodeableConcept>
-  device?: Maybe<ResourceReference>
-  effective?: Maybe<ObservationEffective>
+  basedOn?: Maybe<ResourceReference>;
+  bodySite?: Maybe<Array<Maybe<CodeableConcept>>>;
+  category?: Maybe<Array<Maybe<CodeableConcept>>>;
+  code: CodeableConcept;
+  comment?: Maybe<Scalars['String']>;
+  component?: Maybe<Array<Maybe<ObservationComponent>>>;
+  context?: Maybe<ResourceReference>;
+  dataAbsentReason?: Maybe<CodeableConcept>;
+  device?: Maybe<ResourceReference>;
+  effective?: Maybe<ObservationEffective>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Logical Id of the resource. */
-  id: Scalars['ID']
-  identifier?: Maybe<Array<Maybe<Identifier>>>
-  interpretation?: Maybe<CodeableConcept>
+  id: Scalars['ID'];
+  identifier?: Maybe<Array<Maybe<Identifier>>>;
+  interpretation?: Maybe<CodeableConcept>;
   /** Flag to state whether the resource should be displayed as entered in error in user interface */
-  isEnteredInError?: Maybe<Scalars['Boolean']>
-  issued?: Maybe<PartialDateTime>
+  isEnteredInError?: Maybe<Scalars['Boolean']>;
+  issued?: Maybe<PartialDateTime>;
   /** Metadata about the resource. */
-  metadata: Metadata
-  method?: Maybe<CodeableConcept>
-  performer?: Maybe<Array<Maybe<ResourceReference>>>
-  referenceRange?: Maybe<Array<Maybe<ObservationReferenceRange>>>
-  related?: Maybe<Array<Maybe<ObservationReferenceRange>>>
-  specimen?: Maybe<ResourceReference>
-  status: ObservationStatusCode
+  metadata: Metadata;
+  method?: Maybe<CodeableConcept>;
+  performer?: Maybe<Array<Maybe<ResourceReference>>>;
+  referenceRange?: Maybe<Array<Maybe<ObservationReferenceRange>>>;
+  related?: Maybe<Array<Maybe<ObservationReferenceRange>>>;
+  specimen?: Maybe<ResourceReference>;
+  status: ObservationStatusCode;
   /** Text summary of the resource, for human interpretation. */
-  text?: Maybe<Narrative>
-  value?: Maybe<ObservationValue>
-}
+  text?: Maybe<Narrative>;
+  value?: Maybe<ObservationValue>;
+};
 
 /** Component results */
 export type ObservationComponent = {
-  code: CodeableConcept
-  dataAbsentReason?: Maybe<CodeableConcept>
+  code: CodeableConcept;
+  dataAbsentReason?: Maybe<CodeableConcept>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
-  interpretation?: Maybe<CodeableConcept>
-  referenceRange?: Maybe<Array<Maybe<ObservationReferenceRange>>>
-  value?: Maybe<ObservationValue>
-}
+  extension?: Maybe<Array<Maybe<Extension>>>;
+  interpretation?: Maybe<CodeableConcept>;
+  referenceRange?: Maybe<Array<Maybe<ObservationReferenceRange>>>;
+  value?: Maybe<ObservationValue>;
+};
 
 /** Clinically relevant time/time-period for observation */
 export type ObservationEffective = {
-  effectiveDateTime?: Maybe<PartialDateTime>
-  effectivePeriod?: Maybe<Period>
+  effectiveDateTime?: Maybe<PartialDateTime>;
+  effectivePeriod?: Maybe<Period>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
-}
+  extension?: Maybe<Array<Maybe<Extension>>>;
+};
 
 /** Provides guide for interpretation */
 export type ObservationReferenceRange = {
-  age?: Maybe<Range>
-  appliesTo?: Maybe<Array<Maybe<CodeableConcept>>>
+  age?: Maybe<Range>;
+  appliesTo?: Maybe<Array<Maybe<CodeableConcept>>>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
-  high?: Maybe<Quantity>
-  low?: Maybe<Quantity>
-  text?: Maybe<Scalars['String']>
-  type?: Maybe<CodeableConcept>
-}
+  extension?: Maybe<Array<Maybe<Extension>>>;
+  high?: Maybe<Quantity>;
+  low?: Maybe<Quantity>;
+  text?: Maybe<Scalars['String']>;
+  type?: Maybe<CodeableConcept>;
+};
 
 /**  Codes providing the status of an observation */
 export enum ObservationStatusCode {
@@ -2299,492 +2351,520 @@ export enum ObservationStatusCode {
   Final = 'FINAL',
   Preliminary = 'PRELIMINARY',
   Registered = 'REGISTERED',
-  Unknown = 'UNKNOWN',
+  Unknown = 'UNKNOWN'
 }
 
 /** Actual result */
 export type ObservationValue = {
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
-  valueAttachment?: Maybe<Attachment>
-  valueBoolean?: Maybe<Scalars['Boolean']>
-  valueCodeableConcept?: Maybe<CodeableConcept>
-  valueDateTime?: Maybe<PartialDateTime>
-  valuePeriod?: Maybe<Period>
-  valueQuantity?: Maybe<Quantity>
-  valueRange?: Maybe<Range>
-  valueRatio?: Maybe<Ratio>
-  valueSampledData?: Maybe<SampledData>
-  valueString?: Maybe<Scalars['String']>
-}
+  extension?: Maybe<Array<Maybe<Extension>>>;
+  valueAttachment?: Maybe<Attachment>;
+  valueBoolean?: Maybe<Scalars['Boolean']>;
+  valueCodeableConcept?: Maybe<CodeableConcept>;
+  valueDateTime?: Maybe<PartialDateTime>;
+  valuePeriod?: Maybe<Period>;
+  valueQuantity?: Maybe<Quantity>;
+  valueRange?: Maybe<Range>;
+  valueRatio?: Maybe<Ratio>;
+  valueSampledData?: Maybe<SampledData>;
+  valueString?: Maybe<Scalars['String']>;
+};
+
+/** Operation Parameter */
+export type Parameter = {
+  /** Unique id for inter-element referencing. */
+  elementId?: Maybe<Scalars['String']>;
+  /** Additional content defined by implementations. */
+  extension?: Maybe<Array<Maybe<Extension>>>;
+  name?: Maybe<Scalars['String']>;
+  valueBoolean?: Maybe<Scalars['Boolean']>;
+  valueCode?: Maybe<Scalars['String']>;
+  valueCodeableConcept?: Maybe<CodeableConcept>;
+  valueCoding?: Maybe<Coding>;
+  valueDateTime?: Maybe<PartialDateTime>;
+  valueInt?: Maybe<Scalars['Int']>;
+  valueString?: Maybe<Scalars['String']>;
+  valueUrl?: Maybe<Scalars['String']>;
+  valueUuid?: Maybe<Scalars['Guid']>;
+};
+
+/** Operation Request or Response */
+export type Parameters = {
+  /** Logical Id of the resource. */
+  id: Scalars['ID'];
+  /** Metadata about the resource. */
+  metadata: Metadata;
+  parameter?: Maybe<Array<Maybe<Parameter>>>;
+};
 
 /** A Date + Time, Year, Year + Month, or just a Time. */
 export type PartialDateTime = {
   /** Describes what the value represents – a full full or partial DateTime. */
-  kind?: Maybe<PartialDateTimeKindCode>
+  kind?: Maybe<PartialDateTimeKindCode>;
   /** Represents a point in time, typically expressed as a date and time of day, relative to Coordinated Universal Time (UTC). */
-  value?: Maybe<Scalars['DateTimeOffset']>
-}
+  value?: Maybe<Scalars['DateTimeOffset']>;
+};
 
 /** A Date + Time, Year, Year + Month, or just a Time. */
 export type PartialDateTimeInput = {
   /** yyyy-MM-dd'T'HH:mm:ss.FFFFFFFK, yyyy-MM-dd HH:mm:ss, yyyy-MM-dd, yyyy-MM, or yyyy. */
-  text: Scalars['String']
-}
+  text: Scalars['String'];
+};
 
 export enum PartialDateTimeKindCode {
   Date = 'DATE',
   DateTime = 'DATE_TIME',
   Time = 'TIME',
   Year = 'YEAR',
-  YearMonth = 'YEAR_MONTH',
+  YearMonth = 'YEAR_MONTH'
 }
 
 /** The patient resource represents the patient involved in the provision of healthcare related services. */
 export type Patient = {
   /** Whether this patient's record is in active use. */
-  active?: Maybe<Scalars['Boolean']>
+  active?: Maybe<Scalars['Boolean']>;
   /** Addresses for the individual. */
-  address?: Maybe<Array<Maybe<Address>>>
+  address?: Maybe<Array<Maybe<Address>>>;
   /** The date of birth for the individual. */
-  birthDate?: Maybe<PartialDateTime>
+  birthDate?: Maybe<PartialDateTime>;
   /** A contact party (e.g. guardian, partner, friend) for the patient. */
-  contact?: Maybe<Array<Maybe<PatientContact>>>
+  contact?: Maybe<Array<Maybe<PatientContact>>>;
   /** Indicates if the individual is deceased or not. */
-  deceased?: Maybe<PatientDeceased>
+  deceased?: Maybe<PatientDeceased>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** The gender of a person used for administrative purposes. */
-  gender?: Maybe<AdministrativeGenderCode>
+  gender?: Maybe<AdministrativeGenderCode>;
   /** Patient's nominated primary care provider. */
-  generalPractitioner?: Maybe<Array<Maybe<ResourceReference>>>
+  generalPractitioner?: Maybe<Array<Maybe<ResourceReference>>>;
   /** Logical Id of the resource. */
-  id: Scalars['ID']
+  id: Scalars['ID'];
   /** An identifier for this patient. */
-  identifier?: Maybe<Array<Maybe<Identifier>>>
+  identifier?: Maybe<Array<Maybe<Identifier>>>;
   /** Flag to state whether the resource should be displayed as entered in error in user interface */
-  isEnteredInError?: Maybe<Scalars['Boolean']>
+  isEnteredInError?: Maybe<Scalars['Boolean']>;
   /** Link to another patient resource that concerns the same actual person. */
-  link?: Maybe<Array<Maybe<PatientLink>>>
+  link?: Maybe<Array<Maybe<PatientLink>>>;
   /** Organization that is the custodian of the patient record. */
-  managingOrganization?: Maybe<Array<Maybe<ResourceReference>>>
+  managingOrganization?: Maybe<Array<Maybe<ResourceReference>>>;
   /** Marital (civil) status of a patient. https://fhir.hl7.org.uk/STU3/ValueSet/CareConnect-MaritalStatus-1 */
-  maritalStatus?: Maybe<CodeableConcept>
+  maritalStatus?: Maybe<CodeableConcept>;
   /** Metadata about the resource. */
-  metadata: Metadata
+  metadata: Metadata;
   /** Whether patient is part of a multiple birth. */
-  multipleBirth?: Maybe<PatientMultipleBirth>
+  multipleBirth?: Maybe<PatientMultipleBirth>;
   /** A name associated with the patient. */
-  name: Array<Maybe<HumanName>>
+  name: Array<Maybe<HumanName>>;
   /** Image of the patient. */
-  photo?: Maybe<Array<Maybe<Attachment>>>
+  photo?: Maybe<Array<Maybe<Attachment>>>;
   /** A contact detail for the individual. */
-  telecom?: Maybe<Array<Maybe<ContactPoint>>>
+  telecom?: Maybe<Array<Maybe<ContactPoint>>>;
   /** Text summary of the resource, for human interpretation. */
-  text?: Maybe<Narrative>
-}
+  text?: Maybe<Narrative>;
+};
 
 /** A contact party (e.g. guardian, partner, friend) for the patient. */
 export type PatientContact = {
   /** Address for the contact person. */
-  address?: Maybe<Address>
+  address?: Maybe<Address>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** The gender of a person used for administrative purposes. */
-  gender?: Maybe<AdministrativeGenderCode>
+  gender?: Maybe<AdministrativeGenderCode>;
   /** A name associated with the contact person. */
-  name: HumanName
+  name: HumanName;
   /** Organization that is associated with the contact. */
-  organization?: Maybe<ResourceReference>
+  organization?: Maybe<ResourceReference>;
   /** The period during which this contact person or organization is valid to be contacted relating to this patient. */
-  period?: Maybe<Period>
+  period?: Maybe<Period>;
   /** The nature of the relationship between a patient and a contact person for that patient. http://hl7.org/fhir/stu3/ValueSet/v2-0131 */
-  relationship?: Maybe<Array<Maybe<CodeableConcept>>>
+  relationship?: Maybe<Array<Maybe<CodeableConcept>>>;
   /** A contact detail for the person. */
-  telecom?: Maybe<Array<Maybe<ContactPoint>>>
-}
+  telecom?: Maybe<Array<Maybe<ContactPoint>>>;
+};
 
 /** Indicates if the individual is deceased or not. */
 export type PatientDeceased = {
   /** Indicates if the individual is deceased or not. */
-  deceasedBoolean?: Maybe<Scalars['Boolean']>
+  deceasedBoolean?: Maybe<Scalars['Boolean']>;
   /** Indicates when the patient died. */
-  deceasedDateTime?: Maybe<PartialDateTime>
+  deceasedDateTime?: Maybe<PartialDateTime>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
-}
+  extension?: Maybe<Array<Maybe<Extension>>>;
+};
 
 /** Link to another patient resource that concerns the same actual person. */
 export type PatientLink = {
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** The other patient or related person resource that the link refers to. */
-  other: ResourceReference
+  other: ResourceReference;
   /** The type of link between this patient resource and another patient resource. */
-  type: PatientLinkTypeCode
-}
+  type: PatientLinkTypeCode;
+};
 
 /** http://hl7.org/fhir/stu3/valueset-link-type.html */
 export enum PatientLinkTypeCode {
   Refer = 'REFER',
   ReplacedBy = 'REPLACED_BY',
   Replaces = 'REPLACES',
-  SeeAlso = 'SEE_ALSO',
+  SeeAlso = 'SEE_ALSO'
 }
 
 /** Whether patient is part of a multiple birth. */
 export type PatientMultipleBirth = {
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Whether patient is part of a multiple birth. */
-  multipleBirthBoolean?: Maybe<Scalars['Boolean']>
+  multipleBirthBoolean?: Maybe<Scalars['Boolean']>;
   /** Whether patient is part of a multiple birth. */
-  multipleBirthInteger?: Maybe<Scalars['Int']>
-}
+  multipleBirthInteger?: Maybe<Scalars['Int']>;
+};
 
 /** A time period defined by a start and end date/time. */
 export type Period = {
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** End time with inclusive boundary, if not ongoing. */
-  end?: Maybe<PartialDateTime>
+  end?: Maybe<PartialDateTime>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Starting time with inclusive boundary. */
-  start?: Maybe<PartialDateTime>
-}
+  start?: Maybe<PartialDateTime>;
+};
 
 /** https://www.hl7.org/fhir/R4/plandefinition.html */
 export type PlanDefinition = {
   /** Action defined by the plan. */
-  action?: Maybe<Array<Maybe<PlanDefinitionAction>>>
+  action?: Maybe<Array<Maybe<PlanDefinitionAction>>>;
   /** When the plan definition was approved by publisher. */
-  approvalDate?: Maybe<PartialDateTime>
+  approvalDate?: Maybe<PartialDateTime>;
   /** Who authored the content. */
-  author?: Maybe<Array<Maybe<ContactDetail>>>
+  author?: Maybe<Array<Maybe<ContactDetail>>>;
   /** Name of the publisher (organization or individual). */
-  contact?: Maybe<Array<Maybe<ContactDetail>>>
+  contact?: Maybe<Array<Maybe<ContactDetail>>>;
   /** Use and/or publishing restrictions. */
-  copyright?: Maybe<Scalars['String']>
+  copyright?: Maybe<Scalars['String']>;
   /** Date last changed. */
-  date?: Maybe<PartialDateTime>
+  date?: Maybe<PartialDateTime>;
   /** Natural language description of the plan definition. */
-  description?: Maybe<Scalars['String']>
+  description?: Maybe<Scalars['String']>;
   /** Who edited the content. */
-  editor?: Maybe<Array<Maybe<ContactDetail>>>
+  editor?: Maybe<Array<Maybe<ContactDetail>>>;
   /** When the plan definition is expected to be used. */
-  effectivePeriod?: Maybe<Period>
+  effectivePeriod?: Maybe<Period>;
   /** Who endorsed the content. */
-  endorser?: Maybe<Array<Maybe<ContactDetail>>>
+  endorser?: Maybe<Array<Maybe<ContactDetail>>>;
   /** For testing purposes, not real usage. */
-  experimental?: Maybe<Scalars['Boolean']>
+  experimental?: Maybe<Scalars['Boolean']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** What the plan is trying to accomplish. */
-  goal?: Maybe<Array<Maybe<PlanDefinitionGoal>>>
+  goal?: Maybe<Array<Maybe<PlanDefinitionGoal>>>;
   /** Guidance for problems, interventions etc. */
-  guidance?: Maybe<Array<Maybe<Guidance>>>
+  guidance?: Maybe<Array<Maybe<Guidance>>>;
   /** Logical Id of the resource. */
-  id: Scalars['ID']
+  id: Scalars['ID'];
   /** Additional identifier for the plan definition. */
-  identifier?: Maybe<Array<Maybe<Identifier>>>
+  identifier?: Maybe<Array<Maybe<Identifier>>>;
   /** Flag to state whether the resource should be displayed as entered in error in user interface */
-  isEnteredInError?: Maybe<Scalars['Boolean']>
+  isEnteredInError?: Maybe<Scalars['Boolean']>;
   /** Intended jurisdiction for plan definition (if applicable). */
-  jurisdiction?: Maybe<Array<Maybe<CodeableConcept>>>
+  jurisdiction?: Maybe<Array<Maybe<CodeableConcept>>>;
   /** When the plan definition was last reviewed. */
-  lastReviewDate?: Maybe<PartialDateTime>
+  lastReviewDate?: Maybe<PartialDateTime>;
   /** Logic used by the plan definition. */
-  library?: Maybe<Array<Maybe<Scalars['String']>>>
+  library?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Metadata about the resource. */
-  metadata: Metadata
+  metadata: Metadata;
   /** Name for this plan definition (computer friendly). */
-  name?: Maybe<Scalars['String']>
+  name?: Maybe<Scalars['String']>;
   /** Name of the publisher (organization or individual). */
-  publisher?: Maybe<Scalars['String']>
+  publisher?: Maybe<Scalars['String']>;
   /** Why this plan definition is defined. */
-  purpose?: Maybe<Scalars['String']>
+  purpose?: Maybe<Scalars['String']>;
   /** Questionnaires that can be used to record interventions and goal progress. */
-  questionnaire?: Maybe<Array<Maybe<Questionnaire>>>
+  questionnaire?: Maybe<Array<Maybe<Questionnaire>>>;
   /** Additional documentation, citations. */
-  relatedArtifact?: Maybe<Array<Maybe<RelatedArtifact>>>
+  relatedArtifact?: Maybe<Array<Maybe<RelatedArtifact>>>;
   /** Who reviewed the content. */
-  reviewer?: Maybe<Array<Maybe<ContactDetail>>>
+  reviewer?: Maybe<Array<Maybe<ContactDetail>>>;
   /** draft | active | retired | unknown */
-  status: PlanDefinitionStatus
+  status: PlanDefinitionStatus;
   /** Subordinate title of the plan definition. */
-  subTitle?: Maybe<Scalars['String']>
+  subTitle?: Maybe<Scalars['String']>;
   /** Text summary of the resource, for human interpretation. */
-  text?: Maybe<Narrative>
+  text?: Maybe<Narrative>;
   /** Name for this plan definition (human friendly). */
-  title?: Maybe<Scalars['String']>
+  title?: Maybe<Scalars['String']>;
   /** Keywords defined by the Care Plan Definition. */
-  topic?: Maybe<Array<Maybe<CodeableConcept>>>
+  topic?: Maybe<Array<Maybe<CodeableConcept>>>;
   /** order-set | clinical-protocol | eca-rule | workflow-definition */
-  type?: Maybe<CodeableConcept>
+  type?: Maybe<CodeableConcept>;
   /** Canonical identifier for this plan definition, represented as a URI (globally unique) */
-  url?: Maybe<Scalars['String']>
+  url?: Maybe<Scalars['String']>;
   /** Describes the clinical usage of the plan. */
-  usage?: Maybe<Scalars['String']>
+  usage?: Maybe<Scalars['String']>;
   /** Describes the clinical usage of the plan. */
-  useContext?: Maybe<Array<Maybe<UsageContext>>>
+  useContext?: Maybe<Array<Maybe<UsageContext>>>;
   /** Business version of the plan definition. */
-  version?: Maybe<Scalars['String']>
-}
+  version?: Maybe<Scalars['String']>;
+};
 
 /** https://www.hl7.org/fhir/R4/plandefinition-definitions.html#PlanDefinition.action */
 export type PlanDefinitionAction = {
   /** A sub-action. */
-  action?: Maybe<Array<Maybe<PlanDefinitionAction>>>
+  action?: Maybe<Array<Maybe<PlanDefinitionAction>>>;
   /** Code representing the meaning of the action or sub-model. */
-  code?: Maybe<Array<Maybe<CodeableConcept>>>
+  code?: Maybe<Array<Maybe<CodeableConcept>>>;
   /** Brief description of the action. */
-  description?: Maybe<Scalars['String']>
+  description?: Maybe<Scalars['String']>;
   /** Supporting documentation for the intended performer of the action. */
-  documentation?: Maybe<Array<Maybe<RelatedArtifact>>>
+  documentation?: Maybe<Array<Maybe<RelatedArtifact>>>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** ID of the Goal this action links to */
-  goalId?: Maybe<Array<Maybe<Scalars['String']>>>
+  goalId?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** User-visible prefix for the action (e.g. 1. or A.). */
-  prefix?: Maybe<Scalars['String']>
+  prefix?: Maybe<Scalars['String']>;
   /** Action priority. */
-  priority?: Maybe<PlanDefinitionActionPriority>
+  priority?: Maybe<PlanDefinitionActionPriority>;
   /** Why the action should be performed. */
-  reason?: Maybe<Array<Maybe<CodeableConcept>>>
+  reason?: Maybe<Array<Maybe<CodeableConcept>>>;
   /** Static text equivalent of the action, used if the dynamic aspects cannot be interpreted by the receiving system. */
-  textEquivalent?: Maybe<Scalars['String']>
+  textEquivalent?: Maybe<Scalars['String']>;
   /** User-visible title. */
-  title?: Maybe<Scalars['String']>
-}
+  title?: Maybe<Scalars['String']>;
+};
 
 export enum PlanDefinitionActionPriority {
   Asap = 'ASAP',
   Routine = 'ROUTINE',
   Stat = 'STAT',
-  Urgent = 'URGENT',
+  Urgent = 'URGENT'
 }
 
 /** A continuation of Plan Definition resources. */
 export type PlanDefinitionContinuationType = {
   /** The first cursor token. */
-  firstCursorToken?: Maybe<Scalars['String']>
+  firstCursorToken?: Maybe<Scalars['String']>;
   /** The next cursor token. */
-  nextCursorToken?: Maybe<Scalars['String']>
+  nextCursorToken?: Maybe<Scalars['String']>;
   /** The continuation of Plan Definition resources. */
-  resources: Array<Maybe<PlanDefinition>>
+  resources: Array<Maybe<PlanDefinition>>;
   /** The self cursor token. */
-  selfCursorToken: Scalars['String']
+  selfCursorToken: Scalars['String'];
   /** The total number of resources available (if known). */
-  totalResources?: Maybe<Scalars['Int']>
-}
+  totalResources?: Maybe<Scalars['Int']>;
+};
 
 /** https://www.hl7.org/fhir/plandefinition-definitions.html#PlanDefinition.goal */
 export type PlanDefinitionGoal = {
   /** What does the goal address. */
-  addresses?: Maybe<Array<Maybe<CodeableConcept>>>
+  addresses?: Maybe<Array<Maybe<CodeableConcept>>>;
   /** Goal category. */
-  category?: Maybe<CodeableConcept>
+  category?: Maybe<CodeableConcept>;
   /** Code or text describing the goal. */
-  description: CodeableConcept
+  description: CodeableConcept;
   /** Supporting documentation for the goal. */
-  documentation?: Maybe<Array<Maybe<RelatedArtifact>>>
+  documentation?: Maybe<Array<Maybe<RelatedArtifact>>>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Goal priority. */
-  priority?: Maybe<CodeableConcept>
+  priority?: Maybe<CodeableConcept>;
   /** When goal pursuit begins. */
-  start?: Maybe<CodeableConcept>
+  start?: Maybe<CodeableConcept>;
   /** Target outcome for the goal. */
-  target?: Maybe<Array<Maybe<PlanDefinitionGoalTarget>>>
-}
+  target?: Maybe<Array<Maybe<PlanDefinitionGoalTarget>>>;
+};
 
 /** https://www.hl7.org/fhir/plandefinition-definitions.html#PlanDefinition.goal.target */
 export type PlanDefinitionGoalTarget = {
   /** The target value to be achieved. */
-  detailCodeableConcept?: Maybe<CodeableConcept>
+  detailCodeableConcept?: Maybe<CodeableConcept>;
   /** The target value to be achieved. */
-  detailQuantity?: Maybe<Quantity>
+  detailQuantity?: Maybe<Quantity>;
   /** The target value to be achieved. */
-  detailRange?: Maybe<Range>
+  detailRange?: Maybe<Range>;
   /** Reach goal within. */
-  due?: Maybe<Scalars['String']>
+  due?: Maybe<Scalars['String']>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** The parameter whose value is to be tracked. */
-  measure?: Maybe<CodeableConcept>
-}
+  measure?: Maybe<CodeableConcept>;
+};
 
 export enum PlanDefinitionStatus {
   Active = 'ACTIVE',
   Draft = 'DRAFT',
   Retired = 'RETIRED',
-  Unknown = 'UNKNOWN',
+  Unknown = 'UNKNOWN'
 }
 
 export enum PriorityCode {
   Asap = 'ASAP',
   Normal = 'NORMAL',
   Stat = 'STAT',
-  Urgent = 'URGENT',
+  Urgent = 'URGENT'
 }
 
 /** A measured amount (or an amount that can potentially be measured). */
 export type Quantity = {
   /** Coded form of the unit. */
-  code?: Maybe<Scalars['String']>
+  code?: Maybe<Scalars['String']>;
   /** < | <= | >= | > - how to understand the value. */
-  comparator?: Maybe<QuantityComparatorCode>
+  comparator?: Maybe<QuantityComparatorCode>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** System that defines coded unit form. */
-  system?: Maybe<Scalars['String']>
+  system?: Maybe<Scalars['String']>;
   /** Unit representation. */
-  unit?: Maybe<Scalars['String']>
+  unit?: Maybe<Scalars['String']>;
   /** Numerical value (with implicit precision). */
-  value?: Maybe<Scalars['Decimal']>
-}
+  value?: Maybe<Scalars['Decimal']>;
+};
 
 export enum QuantityComparatorCode {
   GreaterOrEqualTo = 'GREATER_OR_EQUAL_TO',
   GreaterThan = 'GREATER_THAN',
   LessOrEqualTo = 'LESS_OR_EQUAL_TO',
-  LessThan = 'LESS_THAN',
+  LessThan = 'LESS_THAN'
 }
 
 export type Query = {
-  ehr?: Maybe<Ehr>
-  featureToggles?: Maybe<Array<Maybe<FeatureToggle>>>
-  gpConnect?: Maybe<GpConnect>
-  lypft?: Maybe<Lypft>
-  user?: Maybe<User>
-  yhcr?: Maybe<Yhcr>
-}
+  ehr?: Maybe<Ehr>;
+  featureToggles?: Maybe<Array<Maybe<FeatureToggle>>>;
+  gpConnect?: Maybe<GpConnect>;
+  lypft?: Maybe<Lypft>;
+  user?: Maybe<User>;
+  yhcr?: Maybe<Yhcr>;
+};
+
 
 export type QueryYhcrArgs = {
-  dataSourceProfile?: Maybe<DataSourceProfile>
-  reasonForAccess: ReasonForAccessCode
-}
+  dataSourceProfile?: Maybe<DataSourceProfile>;
+  reasonForAccess: ReasonForAccessCode;
+};
 
 /** A structured set of questions intended to guide the collection of answers from end-users. Questionnaires provide detailed control over order, presentation, phraseology and grouping to allow coherent, consistent data collection. */
 export type Questionnaire = {
   /** When the questionnaire was approved by publisher. */
-  approvalDate?: Maybe<PartialDateTime>
+  approvalDate?: Maybe<PartialDateTime>;
   /** Concept that represents the overall questionnaire. */
-  code?: Maybe<Array<Maybe<Coding>>>
+  code?: Maybe<Array<Maybe<Coding>>>;
   /** Contact details for the publisher. */
-  contact?: Maybe<Array<Maybe<ContactDetail>>>
+  contact?: Maybe<Array<Maybe<ContactDetail>>>;
   /** Use and/or publishing restrictions. */
-  copyright?: Maybe<Scalars['String']>
+  copyright?: Maybe<Scalars['String']>;
   /** Date last changed. */
-  date?: Maybe<PartialDateTime>
+  date?: Maybe<PartialDateTime>;
   /** Instantiates protocol or definition. */
-  derivedFrom?: Maybe<Array<Maybe<ResourceReference>>>
+  derivedFrom?: Maybe<Array<Maybe<ResourceReference>>>;
   /** Natural language description of the questionnaire. */
-  description?: Maybe<Scalars['String']>
+  description?: Maybe<Scalars['String']>;
   /** When the questionnaire is expected to be used. */
-  effectivePeriod?: Maybe<Period>
+  effectivePeriod?: Maybe<Period>;
   /** For testing purposes, not real usage. */
-  experimental?: Maybe<Scalars['Boolean']>
+  experimental?: Maybe<Scalars['Boolean']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Logical Id of the resource. */
-  id: Scalars['ID']
+  id: Scalars['ID'];
   /** Additional identifier for the questionnaire. */
-  identifier: Array<Maybe<Identifier>>
+  identifier: Array<Maybe<Identifier>>;
   /** Flag to state whether the resource should be displayed as entered in error in user interface */
-  isEnteredInError?: Maybe<Scalars['Boolean']>
+  isEnteredInError?: Maybe<Scalars['Boolean']>;
   /** Questions and sections within the Questionnaire. */
-  item?: Maybe<Array<Maybe<QuestionnaireItem>>>
+  item?: Maybe<Array<Maybe<QuestionnaireItem>>>;
   /** Intended jurisdiction for questionnaire (if applicable). */
-  jurisdiction?: Maybe<Array<Maybe<CodeableConcept>>>
+  jurisdiction?: Maybe<Array<Maybe<CodeableConcept>>>;
   /** When the questionnaire was last reviewed. */
-  lastReviewDate?: Maybe<PartialDateTime>
+  lastReviewDate?: Maybe<PartialDateTime>;
   /** Metadata about the resource. */
-  metadata: Metadata
+  metadata: Metadata;
   /** Name for this questionnaire (computer friendly). */
-  name?: Maybe<Scalars['String']>
+  name?: Maybe<Scalars['String']>;
   /** Name of the publisher (organization or individual). */
-  publisher?: Maybe<Scalars['String']>
+  publisher?: Maybe<Scalars['String']>;
   /** Why this questionnaire is defined. */
-  purpose?: Maybe<Scalars['String']>
+  purpose?: Maybe<Scalars['String']>;
   /** Why this questionnaire is defined. */
-  status: QuestionnairePublicationStatus
+  status: QuestionnairePublicationStatus;
   /** Resource that can be subject of QuestionnaireResponse. */
-  subjectType?: Maybe<Array<Maybe<Scalars['String']>>>
+  subjectType?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Text summary of the resource, for human interpretation. */
-  text?: Maybe<Narrative>
+  text?: Maybe<Narrative>;
   /** Name for this questionnaire (human friendly). */
-  title?: Maybe<Scalars['String']>
+  title?: Maybe<Scalars['String']>;
   /** Canonical identifier for this questionnaire, represented as a URI (globally unique). */
-  url?: Maybe<Scalars['String']>
+  url?: Maybe<Scalars['String']>;
   /** The context that the content is intended to support. */
-  useContext?: Maybe<Array<Maybe<UsageContext>>>
+  useContext?: Maybe<Array<Maybe<UsageContext>>>;
   /** Business version of the questionnaire. */
-  version?: Maybe<Scalars['String']>
-}
+  version?: Maybe<Scalars['String']>;
+};
 
 /** Questions and sections within the Questionnaire. */
 export type QuestionnaireItem = {
   /** Permitted answer. */
-  answerOption?: Maybe<Array<Maybe<QuestionnaireItemAnswerOption>>>
+  answerOption?: Maybe<Array<Maybe<QuestionnaireItemAnswerOption>>>;
   /** Corresponding concept for this item in a terminology. */
-  code?: Maybe<Array<Maybe<Coding>>>
+  code?: Maybe<Array<Maybe<Coding>>>;
   /** ElementDefinition - details for the item. */
-  definition?: Maybe<Scalars['String']>
+  definition?: Maybe<Scalars['String']>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Nested questionnaire response items. */
-  item?: Maybe<Array<Maybe<QuestionnaireItem>>>
+  item?: Maybe<Array<Maybe<QuestionnaireItem>>>;
   /** Unique id for item in questionnaire. */
-  linkId?: Maybe<Scalars['String']>
+  linkId?: Maybe<Scalars['String']>;
   /** No more than this many characters. */
-  maxLength?: Maybe<Scalars['Int']>
+  maxLength?: Maybe<Scalars['Int']>;
   /** E.g. '1(a)', '2.5.3'. */
-  prefix?: Maybe<Scalars['String']>
+  prefix?: Maybe<Scalars['String']>;
   /** Whether the item may repeat. */
-  repeats?: Maybe<Scalars['Boolean']>
+  repeats?: Maybe<Scalars['Boolean']>;
   /** Whether the item must be included in data results. */
-  required?: Maybe<Scalars['Boolean']>
+  required?: Maybe<Scalars['Boolean']>;
   /** Primary text for the item. */
-  text?: Maybe<Scalars['String']>
+  text?: Maybe<Scalars['String']>;
   /** Data type. */
-  type: QuestionnaireItemTypeCode
-}
+  type: QuestionnaireItemTypeCode;
+};
 
 /** Permitted answer. */
 export type QuestionnaireItemAnswerOption = {
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Whether option is selected by default */
-  initialSelected?: Maybe<Scalars['Boolean']>
+  initialSelected?: Maybe<Scalars['Boolean']>;
   /** Answer value */
-  valueCoding?: Maybe<Coding>
+  valueCoding?: Maybe<Coding>;
   /** Answer value */
-  valueString?: Maybe<Scalars['String']>
-}
+  valueString?: Maybe<Scalars['String']>;
+};
 
 export enum QuestionnaireItemTypeCode {
   Display = 'DISPLAY',
@@ -2798,129 +2878,129 @@ export enum QuestionnaireItemTypeCode {
   QuestionStringBbCode = 'QUESTION_STRING_BB_CODE',
   QuestionStringHtml = 'QUESTION_STRING_HTML',
   QuestionText = 'QUESTION_TEXT',
-  Unknown = 'UNKNOWN',
+  Unknown = 'UNKNOWN'
 }
 
 export enum QuestionnairePublicationStatus {
   Active = 'ACTIVE',
   Draft = 'DRAFT',
   Retired = 'RETIRED',
-  Unknown = 'UNKNOWN',
+  Unknown = 'UNKNOWN'
 }
 
 /** A structured set of questions and their answers. The questions are ordered and grouped into coherent subsets, corresponding to the structure of the grouping of the questionnaire being responded to. */
 export type QuestionnaireResponse = {
   /** Person who received and recorded the answers. */
-  author?: Maybe<ResourceReference>
+  author?: Maybe<ResourceReference>;
   /** Date the answers were gathered. */
-  authored?: Maybe<PartialDateTime>
+  authored?: Maybe<PartialDateTime>;
   /** Request fulfilled by this QuestionnaireResponse. */
-  basedOn?: Maybe<ResourceReference>
+  basedOn?: Maybe<ResourceReference>;
   /** Encounter created as part of. */
-  encounter?: Maybe<ResourceReference>
+  encounter?: Maybe<ResourceReference>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Logical Id of the resource. */
-  id: Scalars['ID']
+  id: Scalars['ID'];
   /** Unique id for this set of answers. */
-  identifier?: Maybe<Identifier>
+  identifier?: Maybe<Identifier>;
   /** Flag to state whether the resource should be displayed as entered in error in user interface */
-  isEnteredInError?: Maybe<Scalars['Boolean']>
+  isEnteredInError?: Maybe<Scalars['Boolean']>;
   /** Groups and questions. */
-  item?: Maybe<Array<Maybe<QuestionnaireResponseItem>>>
+  item?: Maybe<Array<Maybe<QuestionnaireResponseItem>>>;
   /** Metadata about the resource. */
-  metadata: Metadata
+  metadata: Metadata;
   /** Part of this action. */
-  partOf?: Maybe<ResourceReference>
+  partOf?: Maybe<ResourceReference>;
   /** Form being answered. */
-  questionnaire?: Maybe<Questionnaire>
+  questionnaire?: Maybe<Questionnaire>;
   /** The person who answered the questions. */
-  source?: Maybe<ResourceReference>
+  source?: Maybe<ResourceReference>;
   /** Why this questionnaire is defined. */
-  status: QuestionnaireResponseStatus
+  status: QuestionnaireResponseStatus;
   /** Text summary of the resource, for human interpretation. */
-  text?: Maybe<Narrative>
-}
+  text?: Maybe<Narrative>;
+};
 
 /** A continuation of Questionnaire Response resources. */
 export type QuestionnaireResponseContinuation = {
   /** The first cursor token. */
-  firstCursorToken?: Maybe<Scalars['String']>
+  firstCursorToken?: Maybe<Scalars['String']>;
   /** The next cursor token. */
-  nextCursorToken?: Maybe<Scalars['String']>
+  nextCursorToken?: Maybe<Scalars['String']>;
   /** The continuation of Questionnaire Response resources. */
-  resources: Array<Maybe<QuestionnaireResponse>>
+  resources: Array<Maybe<QuestionnaireResponse>>;
   /** The self cursor token. */
-  selfCursorToken: Scalars['String']
+  selfCursorToken: Scalars['String'];
   /** The total number of resources available (if known). */
-  totalResources?: Maybe<Scalars['Int']>
-}
+  totalResources?: Maybe<Scalars['Int']>;
+};
 
 /** Groups and questions. */
 export type QuestionnaireResponseItem = {
   /** The response(s) to the question. */
-  answer?: Maybe<Array<Maybe<QuestionnaireResponseItemAnswer>>>
+  answer?: Maybe<Array<Maybe<QuestionnaireResponseItemAnswer>>>;
   /** ElementDefinition - details for the item. */
-  definition?: Maybe<Scalars['String']>
+  definition?: Maybe<Scalars['String']>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Nested questionnaire response items. */
-  item?: Maybe<Array<Maybe<QuestionnaireResponseItem>>>
+  item?: Maybe<Array<Maybe<QuestionnaireResponseItem>>>;
   /** Pointer to specific item from Questionnaire. */
-  linkId?: Maybe<Scalars['String']>
+  linkId?: Maybe<Scalars['String']>;
   /** Name for group or question text. */
-  text?: Maybe<Scalars['String']>
-}
+  text?: Maybe<Scalars['String']>;
+};
 
 /** The response(s) to the question. */
 export type QuestionnaireResponseItemAnswer = {
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Nested groups and questions. */
-  item?: Maybe<Array<Maybe<QuestionnaireResponseItem>>>
+  item?: Maybe<Array<Maybe<QuestionnaireResponseItem>>>;
   /** Boolean Value. */
-  valueBoolean?: Maybe<Scalars['Boolean']>
+  valueBoolean?: Maybe<Scalars['Boolean']>;
   /** Coding Value. */
-  valueCoding?: Maybe<Coding>
+  valueCoding?: Maybe<Coding>;
   /** Date Time Value. */
-  valueDateTime?: Maybe<PartialDateTime>
+  valueDateTime?: Maybe<PartialDateTime>;
   /** String Value. */
-  valueString?: Maybe<Scalars['String']>
-}
+  valueString?: Maybe<Scalars['String']>;
+};
 
 export enum QuestionnaireResponseStatus {
   Amended = 'AMENDED',
   Completed = 'COMPLETED',
   EnteredInError = 'ENTERED_IN_ERROR',
   InProgress = 'IN_PROGRESS',
-  Stopped = 'STOPPED',
+  Stopped = 'STOPPED'
 }
 
 /** A set of ordered Quantity values defined by a low and high limit. */
 export type Range = {
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Low limit. */
-  high?: Maybe<Quantity>
+  high?: Maybe<Quantity>;
   /** High limit. */
-  low?: Maybe<Quantity>
-}
+  low?: Maybe<Quantity>;
+};
 
 /** A relationship between two Quantity values expressed as a numerator and a denominator. */
 export type Ratio = {
-  denominator?: Maybe<Quantity>
+  denominator?: Maybe<Quantity>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
-  numerator?: Maybe<Quantity>
-}
+  extension?: Maybe<Array<Maybe<Extension>>>;
+  numerator?: Maybe<Quantity>;
+};
 
 /** The reason for accessing the patient record. */
 export enum ReasonForAccessCode {
@@ -2935,30 +3015,30 @@ export enum ReasonForAccessCode {
   /** Indirect care with the consent of the patient. Access is in the context of the patient. */
   IndirectCareInContext = 'INDIRECT_CARE_IN_CONTEXT',
   /** Indirect care not in the context of a patient. (Not patient-centric). */
-  IndirectCareNotInContext = 'INDIRECT_CARE_NOT_IN_CONTEXT',
+  IndirectCareNotInContext = 'INDIRECT_CARE_NOT_IN_CONTEXT'
 }
 
 /** Related artifacts for a knowledge resource. */
 export type RelatedArtifact = {
   /** Bibliographic citation for the artifact. */
-  citation?: Maybe<Scalars['String']>
+  citation?: Maybe<Scalars['String']>;
   /** Brief description of the related artifact. */
-  display?: Maybe<Scalars['String']>
+  display?: Maybe<Scalars['String']>;
   /** What document is being referenced. */
-  document?: Maybe<Attachment>
+  document?: Maybe<Attachment>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Short label. */
-  label?: Maybe<Scalars['String']>
+  label?: Maybe<Scalars['String']>;
   /** What resource is being referenced. */
-  resource?: Maybe<ResourceReference>
+  resource?: Maybe<ResourceReference>;
   /** RelatedArtifactType code. */
-  type: RelatedArtifactType
+  type: RelatedArtifactType;
   /** Where the artifact can be accessed. */
-  url?: Maybe<Scalars['String']>
-}
+  url?: Maybe<Scalars['String']>;
+};
 
 export enum RelatedArtifactType {
   Citation = 'CITATION',
@@ -2968,97 +3048,97 @@ export enum RelatedArtifactType {
   Documentation = 'DOCUMENTATION',
   Justification = 'JUSTIFICATION',
   Predecessor = 'PREDECESSOR',
-  Successor = 'SUCCESSOR',
+  Successor = 'SUCCESSOR'
 }
 
 /** General references between resources. */
 export type ResourceReference = {
   /** Text alternative for the resource. */
-  display: Scalars['String']
+  display: Scalars['String'];
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Business identifier for the referenced resource. */
-  identifier?: Maybe<Identifier>
+  identifier?: Maybe<Identifier>;
   /** Literal reference, Relative, internal or absolute URL. */
-  reference?: Maybe<Scalars['String']>
+  reference?: Maybe<Scalars['String']>;
   /** Type the reference refers to (e.g. Patient. */
-  typeName: Scalars['String']
-}
+  typeName: Scalars['String'];
+};
 
 /** Data that comes from a series of measurements taken by a device, which may have upper and lower limits. The data type also supports more than one dimension in the data. */
 export type SampledData = {
   /** Decimal values with spaces, or "E" | "U" | "L" */
-  data: Scalars['String']
+  data: Scalars['String'];
   /** Number of sample points at each time point */
-  dimensions: Scalars['Int']
+  dimensions: Scalars['Int'];
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Multiply data by this before adding to origin */
-  factor?: Maybe<Scalars['Decimal']>
+  factor?: Maybe<Scalars['Decimal']>;
   /** Lower limit of detection */
-  lowerLimit?: Maybe<Scalars['Decimal']>
+  lowerLimit?: Maybe<Scalars['Decimal']>;
   /** Zero value and units */
-  origin: Quantity
+  origin: Quantity;
   /** Number of milliseconds between samples */
-  period?: Maybe<Scalars['Decimal']>
+  period?: Maybe<Scalars['Decimal']>;
   /** Upper limit of detection */
-  upperLimit?: Maybe<Scalars['Decimal']>
-}
+  upperLimit?: Maybe<Scalars['Decimal']>;
+};
 
 export enum SortOptionType {
   Alphabetical = 'ALPHABETICAL',
-  MostRecent = 'MOST_RECENT',
+  MostRecent = 'MOST_RECENT'
 }
 
 /** https://www.hl7.org/fhir/STU3/task.html */
 export type Task = {
   /** Task Creation Date */
-  authoredOn?: Maybe<PartialDateTime>
+  authoredOn?: Maybe<PartialDateTime>;
   /** NotYetDue, Due, Overdue, Suspended, Completed */
-  businessStatus?: Maybe<CodeableConcept>
+  businessStatus?: Maybe<CodeableConcept>;
   /** Task Type */
-  code?: Maybe<CodeableConcept>
+  code?: Maybe<CodeableConcept>;
   /** Human-readable explanation of task */
-  description?: Maybe<Scalars['String']>
+  description?: Maybe<Scalars['String']>;
   /** Start and end time of execution (start = due date, end = overdue date) */
-  executionPeriod?: Maybe<Period>
+  executionPeriod?: Maybe<Period>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
+  extension?: Maybe<Array<Maybe<Extension>>>;
   /** Logical Id of the resource. */
-  id: Scalars['ID']
+  id: Scalars['ID'];
   /** proposal | plan | order */
-  intent: IntentCode
+  intent: IntentCode;
   /** Flag to state whether the resource should be displayed as entered in error in user interface */
-  isEnteredInError?: Maybe<Scalars['Boolean']>
+  isEnteredInError?: Maybe<Scalars['Boolean']>;
   /** Metadata about the resource. */
-  metadata: Metadata
+  metadata: Metadata;
   /** The action to be performed */
-  performerType: CodeableConcept
+  performerType: CodeableConcept;
   /** normal | urgent | asap | stat */
-  priority?: Maybe<PriorityCode>
+  priority?: Maybe<PriorityCode>;
   /** EHR task status */
-  status: TaskStatusCode
+  status: TaskStatusCode;
   /** Text summary of the resource, for human interpretation. */
-  text?: Maybe<Narrative>
-}
+  text?: Maybe<Narrative>;
+};
 
 /** A continuation of Task resources. */
 export type TaskContinuation = {
   /** The first cursor token. */
-  firstCursorToken?: Maybe<Scalars['String']>
+  firstCursorToken?: Maybe<Scalars['String']>;
   /** The next cursor token. */
-  nextCursorToken?: Maybe<Scalars['String']>
+  nextCursorToken?: Maybe<Scalars['String']>;
   /** The continuation of Task resources. */
-  resources: Array<Maybe<Task>>
+  resources: Array<Maybe<Task>>;
   /** The self cursor token. */
-  selfCursorToken: Scalars['String']
+  selfCursorToken: Scalars['String'];
   /** The total number of resources available (if known). */
-  totalResources?: Maybe<Scalars['Int']>
-}
+  totalResources?: Maybe<Scalars['Int']>;
+};
 
 export enum TaskStatusCode {
   Cancelled = 'CANCELLED',
@@ -3067,66 +3147,66 @@ export enum TaskStatusCode {
   NotYetDue = 'NOT_YET_DUE',
   Overdue = 'OVERDUE',
   Skipped = 'SKIPPED',
-  Suspended = 'SUSPENDED',
+  Suspended = 'SUSPENDED'
 }
 
 /** The terminology item resource represents the terminology for an item in a particular coding system and version for a particular organisation. */
 export type TerminologyItem = {
   /** Code for item */
-  coding: Coding
+  coding: Coding;
   /** Logical Id of the resource. */
-  id: Scalars['ID']
+  id: Scalars['ID'];
   /** Metadata about the resource. */
-  metadata: Metadata
-}
+  metadata: Metadata;
+};
 
 /** A continuation of TerminologyItem resources. */
 export type TerminologyItemContinuation = {
   /** The first cursor token. */
-  firstCursorToken?: Maybe<Scalars['String']>
+  firstCursorToken?: Maybe<Scalars['String']>;
   /** The next cursor token. */
-  nextCursorToken?: Maybe<Scalars['String']>
+  nextCursorToken?: Maybe<Scalars['String']>;
   /** The continuation of TerminologyItem resources. */
-  resources: Array<Maybe<TerminologyItem>>
+  resources: Array<Maybe<TerminologyItem>>;
   /** The self cursor token. */
-  selfCursorToken: Scalars['String']
+  selfCursorToken: Scalars['String'];
   /** The total number of resources available (if known). */
-  totalResources?: Maybe<Scalars['Int']>
-}
+  totalResources?: Maybe<Scalars['Int']>;
+};
 
 export type TimingRepeatType = {
-  boundsDuration?: Maybe<Quantity>
-  boundsPeriod?: Maybe<Period>
-  boundsRange?: Maybe<Range>
-  count?: Maybe<Scalars['Int']>
-  countMax?: Maybe<Scalars['Int']>
-  daysOfWeek?: Maybe<DaysOfWeekType>
-  duration?: Maybe<Scalars['Decimal']>
-  durationMax?: Maybe<Scalars['Decimal']>
-  durationUnit?: Maybe<UnitsOfTimeType>
+  boundsDuration?: Maybe<Quantity>;
+  boundsPeriod?: Maybe<Period>;
+  boundsRange?: Maybe<Range>;
+  count?: Maybe<Scalars['Int']>;
+  countMax?: Maybe<Scalars['Int']>;
+  daysOfWeek?: Maybe<DaysOfWeekType>;
+  duration?: Maybe<Scalars['Decimal']>;
+  durationMax?: Maybe<Scalars['Decimal']>;
+  durationUnit?: Maybe<UnitsOfTimeType>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
-  frequency?: Maybe<Scalars['Int']>
-  frequencyMax?: Maybe<Scalars['Int']>
-  offSet?: Maybe<Scalars['Int']>
-  period?: Maybe<Scalars['Decimal']>
-  periodMax?: Maybe<Scalars['Decimal']>
-  periodUnit?: Maybe<UnitsOfTimeType>
-  timeOfDay?: Maybe<Array<Maybe<Scalars['String']>>>
-  when?: Maybe<Array<Maybe<Scalars['String']>>>
-}
+  extension?: Maybe<Array<Maybe<Extension>>>;
+  frequency?: Maybe<Scalars['Int']>;
+  frequencyMax?: Maybe<Scalars['Int']>;
+  offSet?: Maybe<Scalars['Int']>;
+  period?: Maybe<Scalars['Decimal']>;
+  periodMax?: Maybe<Scalars['Decimal']>;
+  periodUnit?: Maybe<UnitsOfTimeType>;
+  timeOfDay?: Maybe<Array<Maybe<Scalars['String']>>>;
+  when?: Maybe<Array<Maybe<Scalars['String']>>>;
+};
 
 export type TimingType = {
-  code?: Maybe<CodeableConcept>
+  code?: Maybe<CodeableConcept>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
-  event?: Maybe<Array<Maybe<PartialDateTime>>>
+  elementId?: Maybe<Scalars['String']>;
+  event?: Maybe<Array<Maybe<PartialDateTime>>>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
-  repeat?: Maybe<TimingRepeatType>
-}
+  extension?: Maybe<Array<Maybe<Extension>>>;
+  repeat?: Maybe<TimingRepeatType>;
+};
 
 export enum UnitsOfTimeType {
   /** Year */
@@ -3142,99 +3222,107 @@ export enum UnitsOfTimeType {
   /** Second */
   S = 'S',
   /** Week */
-  Wk = 'WK',
+  Wk = 'WK'
 }
 
 export type UsageContext = {
-  code?: Maybe<Coding>
+  code?: Maybe<Coding>;
   /** Unique id for inter-element referencing. */
-  elementId?: Maybe<Scalars['String']>
+  elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */
-  extension?: Maybe<Array<Maybe<Extension>>>
-  valueCodeableConcept?: Maybe<CodeableConcept>
-  valueQuantity?: Maybe<Quantity>
-  valueRange?: Maybe<Range>
-  valueReference?: Maybe<ResourceReference>
-}
+  extension?: Maybe<Array<Maybe<Extension>>>;
+  valueCodeableConcept?: Maybe<CodeableConcept>;
+  valueQuantity?: Maybe<Quantity>;
+  valueRange?: Maybe<Range>;
+  valueReference?: Maybe<ResourceReference>;
+};
 
 /** The currently logged-in User Identity and Permissions. */
 export type User = {
   /** The users contact coding */
-  contact?: Maybe<Coding>
+  contact?: Maybe<Coding>;
   /** The Data Providers the User has access to. */
-  dataProviderPermissions?: Maybe<Array<Maybe<DataProviderPermission>>>
+  dataProviderPermissions?: Maybe<Array<Maybe<DataProviderPermission>>>;
   /** The Resources and Operations the user has access to. */
-  entityPermissions?: Maybe<Array<Maybe<EntityPermission>>>
+  entityPermissions?: Maybe<Array<Maybe<EntityPermission>>>;
   /** The users full name. */
-  fullName: Scalars['String']
+  fullName: Scalars['String'];
   /** Logical Id of the resource. */
-  id: Scalars['ID']
+  id: Scalars['ID'];
   /** The available Launch types the user can make. */
-  launchPermissions?: Maybe<Array<Maybe<LaunchPermission>>>
+  launchPermissions?: Maybe<Array<Maybe<LaunchPermission>>>;
   /** Metadata about the resource. */
-  metadata: Metadata
+  metadata: Metadata;
   /** The users organisation unique identifier. */
-  organisationIdentifier: Scalars['Guid']
+  organisationIdentifier: Scalars['Guid'];
   /** The username. */
-  userName: Scalars['String']
-}
+  userName: Scalars['String'];
+};
 
 /** Queries the YHCR System-of-Systems. */
 export type Yhcr = {
-  allergyIntolerances?: Maybe<Array<Maybe<AllergyIntolerance>>>
-  appointments?: Maybe<EncounterContinuation>
-  condition?: Maybe<Condition>
-  conditions?: Maybe<Array<Maybe<Condition>>>
-  dataAvailability?: Maybe<DataAvailability>
-  documents?: Maybe<DocumentReferenceContinuation>
-  hospitalStays?: Maybe<Array<Maybe<Encounter>>>
-  observations?: Maybe<Array<Maybe<Observation>>>
-}
+  allergyIntolerances?: Maybe<Array<Maybe<AllergyIntolerance>>>;
+  appointments?: Maybe<EncounterContinuation>;
+  condition?: Maybe<Condition>;
+  conditions?: Maybe<Array<Maybe<Condition>>>;
+  dataAvailability?: Maybe<DataAvailability>;
+  documents?: Maybe<DocumentReferenceContinuation>;
+  hospitalStays?: Maybe<Array<Maybe<Encounter>>>;
+  observations?: Maybe<Array<Maybe<Observation>>>;
+};
+
 
 /** Queries the YHCR System-of-Systems. */
 export type YhcrAllergyIntolerancesArgs = {
-  nhsNumber: Scalars['String']
-}
+  nhsNumber: Scalars['String'];
+};
+
 
 /** Queries the YHCR System-of-Systems. */
 export type YhcrAppointmentsArgs = {
-  count?: Maybe<Scalars['Int']>
-  cursorToken?: Maybe<Scalars['String']>
-  nhsNumber: Scalars['String']
-  status?: Maybe<Array<Maybe<EncounterStatusCode>>>
-}
+  count?: Maybe<Scalars['Int']>;
+  cursorToken?: Maybe<Scalars['String']>;
+  nhsNumber: Scalars['String'];
+  status?: Maybe<Array<Maybe<EncounterStatusCode>>>;
+};
+
 
 /** Queries the YHCR System-of-Systems. */
 export type YhcrConditionArgs = {
-  id: Scalars['String']
-  nhsNumber: Scalars['String']
-}
+  id: Scalars['String'];
+  nhsNumber: Scalars['String'];
+};
+
 
 /** Queries the YHCR System-of-Systems. */
 export type YhcrConditionsArgs = {
-  nhsNumber: Scalars['String']
-}
+  nhsNumber: Scalars['String'];
+};
+
 
 /** Queries the YHCR System-of-Systems. */
 export type YhcrDataAvailabilityArgs = {
-  nhsNumber: Scalars['String']
-}
+  nhsNumber: Scalars['String'];
+};
+
 
 /** Queries the YHCR System-of-Systems. */
 export type YhcrDocumentsArgs = {
-  count?: Maybe<Scalars['Int']>
-  cursorToken?: Maybe<Scalars['String']>
-  fromDate: Scalars['Date']
-  nhsNumber: Scalars['String']
-  toDate: Scalars['Date']
-}
+  count?: Maybe<Scalars['Int']>;
+  cursorToken?: Maybe<Scalars['String']>;
+  fromDate: Scalars['Date'];
+  nhsNumber: Scalars['String'];
+  toDate: Scalars['Date'];
+};
+
 
 /** Queries the YHCR System-of-Systems. */
 export type YhcrHospitalStaysArgs = {
-  nhsNumber: Scalars['String']
-}
+  nhsNumber: Scalars['String'];
+};
+
 
 /** Queries the YHCR System-of-Systems. */
 export type YhcrObservationsArgs = {
-  nhsNumber: Scalars['String']
-}
+  nhsNumber: Scalars['String'];
+};


### PR DESCRIPTION
Primarily, this PR adds a new mutation that lets you mark a care plan as complete.

It also adds back some missing types that were accidentally removed during a rebase last week (Parameters types)

It also removes some Entity types

It also stops prettier from complaining about auto generated files (hence the large amount of whitespace & semicolon changes). This is to prevent merge / rebase issues going forward.