### PR TITLE
Updated questionnaire-table-methods to use record.id when mapping

### DIFF
--- a/components/styled/table/src/organisms/questionnaire-table-methods.ts
+++ b/components/styled/table/src/organisms/questionnaire-table-methods.ts
@@ -272,8 +272,9 @@ const createCellPropsForAnswer = (
     }
   }
   if (answer.valueBoolean != null) {
+    const parsedBoolean = answer.valueBoolean ? 'Yes' : 'No'
     return {
-      text: answer.valueBoolean.toString(),
+      text: parsedBoolean,
     }
   }
   if (answer.valueInteger != null) {

--- a/components/styled/table/src/organisms/questionnaire-table-methods.ts
+++ b/components/styled/table/src/organisms/questionnaire-table-methods.ts
@@ -179,13 +179,13 @@ const buildVerticalCellRows = (
     const actionsDataEntity: DataEntity = {}
     actionsDataEntity.property = { text: 'Actions' }
 
-    records.forEach((record, recordIndex) => {
+    records.forEach((record) => {
       const adminActionsForThisDataEntity = adminActions.find(
         (actionForForm) => actionForForm.questionnaire === record.id
       )
 
       if (adminActionsForThisDataEntity) {
-        actionsDataEntity[recordIndex + 1] = {
+        actionsDataEntity[record.id] = {
           adminActions: adminActionsForThisDataEntity.adminActions,
           parentStyle: { zIndex: getZIndex(TableDataWithPopUp) },
         }
@@ -207,12 +207,12 @@ const buildVerticalCellRowsRecursive = (
     updatedDataEntity.property = { text: definitionItem.text ?? '' }
 
     if (definitionItem.linkId) {
-      records.forEach((record, recordIndex) => {
+      records.forEach((record) => {
         updatedDataEntity = getRecordItemByLinkId(
           EnsureMaybeArray<QuestionnaireResponseItem>(record.item ?? []),
           EnsureMaybe<string>(definitionItem.linkId),
           updatedDataEntity,
-          recordIndex
+          record.id
         )
       })
     }
@@ -232,7 +232,7 @@ const getRecordItemByLinkId = (
   recordItems: QuestionnaireResponseItem[],
   linkId: string,
   dataEntity: DataEntity,
-  recordIndex: number
+  recordId: string
 ) => {
   let updatedDataEntity = { ...dataEntity }
   recordItems.forEach((recordItem) => {
@@ -241,14 +241,14 @@ const getRecordItemByLinkId = (
 
     if (recordItemAnswer) {
       if (recordItem?.linkId && recordItem?.linkId === linkId) {
-        updatedDataEntity[recordIndex + 1] = createCellPropsForAnswer(recordItemAnswer, true)
+        updatedDataEntity[recordId] = createCellPropsForAnswer(recordItemAnswer, true)
       }
       if (recordItemAnswer.item && recordItemAnswer.item.length > 0) {
         updatedDataEntity = getRecordItemByLinkId(
           EnsureMaybeArray<QuestionnaireResponseItem>(recordItemAnswer.item),
           linkId,
           updatedDataEntity,
-          recordIndex
+          recordId
         )
       }
     }

--- a/packages/storybook/src/ui/organisms/questionnaire-table/questionnaire-table.mockdata.tsx
+++ b/packages/storybook/src/ui/organisms/questionnaire-table/questionnaire-table.mockdata.tsx
@@ -81,7 +81,7 @@ export const expectedResultOfMappingWithHeadersOnXAxis: TableData = {
       '4i': { text: 'Alert' },
       '4j': { text: '8' },
       '4k': { text: '75' },
-      '4l': { text: 'false' },
+      '4l': { text: 'No' },
       '5': { text: '70.5' },
     },
     {
@@ -117,7 +117,7 @@ export const expectedResultOfMappingWithHeadersOnXAxis: TableData = {
       '4j': { text: '3' },
       '4k': { text: '65' },
       '4l': { text: '20.5' },
-      '5': { text: 'true' },
+      '5': { text: 'Yes' },
     },
     {
       date: { text: '01-Jan-2022 16:02' },
@@ -313,7 +313,7 @@ export const expectedResultOfMappingWithHeadersOnYAxis: TableData = {
         },
         {
           property: { text: 'Spine Pain (VAS)' },
-          '1': { text: 'false' },
+          '1': { text: 'No' },
           '2': { text: '20.5' },
           '3': { text: '45' },
         },
@@ -322,7 +322,7 @@ export const expectedResultOfMappingWithHeadersOnYAxis: TableData = {
     {
       property: { text: 'Average BASFI Score' },
       '1': { text: '70.5' },
-      '2': { text: 'true' },
+      '2': { text: 'Yes' },
       '3': { text: '12.5' },
     },
   ],


### PR DESCRIPTION
This is so the questionnaire table mapping still works when the IDs of the questions are not incremental (previously it used recordIndex+1 which relied on the IDs being incremental from 1 or it would break the mapping on the vertical table)