### PR TITLE
Include pedigree group in patient banner

### DIFF
--- a/components/clinical/patient-banner/src/atoms/ped-number.tsx
+++ b/components/clinical/patient-banner/src/atoms/ped-number.tsx
@@ -18,7 +18,7 @@ const StyledValue = styled.span`
 `
 
 const PedNumber: FC<Props> = ({ patientGroups, ...rest }) => {
-  const pedGroup = patientGroups.find((pg) => pg.id.includes('PED'))
+  const pedGroup = patientGroups.find((pg) => pg.id.startsWith('PED'))
 
   if (pedGroup === undefined) {
     return null

--- a/components/clinical/patient-banner/src/atoms/ped-number.tsx
+++ b/components/clinical/patient-banner/src/atoms/ped-number.tsx
@@ -1,0 +1,39 @@
+import { FC, HTMLAttributes } from 'react'
+import styled from '@emotion/styled'
+import { Group } from '@ltht-react/types'
+
+const StyledPasNumber = styled.div``
+
+const StyledLabel = styled.span`
+  color: #666;
+  font-weight: normal;
+  font-size: 0.75rem;
+`
+
+const StyledValue = styled.span`
+  color: #333333;
+  font-weight: bold;
+  font-size: 0.8125rem;
+  margin-left: 0.5rem;
+`
+
+const PedNumber: FC<Props> = ({ patientGroups, ...rest }) => {
+  const pedGroup = patientGroups.find((pg) => pg.id.includes('PED'))
+
+  if (pedGroup === undefined) {
+    return null
+  }
+
+  return (
+    <StyledPasNumber {...rest}>
+      <StyledLabel>Ped No.</StyledLabel>
+      <StyledValue>{pedGroup.id}</StyledValue>
+    </StyledPasNumber>
+  )
+}
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+  patientGroups: Group[]
+}
+
+export default PedNumber

--- a/components/clinical/patient-banner/src/index.tsx
+++ b/components/clinical/patient-banner/src/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 import styled from '@emotion/styled'
-import { Patient } from '@ltht-react/types'
+import { Group, Patient } from '@ltht-react/types'
 
 import {
   CSS_RESET,
@@ -18,7 +18,7 @@ const StyledPatientBanner = styled.div<StyledPatientBannerProps>`
       : `2px solid ${PATIENT_BANNER_BACKGROUND_COLOUR}`};
 `
 
-const PatientBanner: FC<Props> = ({ patient }) => {
+const PatientBanner: FC<Props> = ({ patient, patientGroups }) => {
   const date = patient?.deceased?.deceasedDateTime
 
   let deceased: boolean
@@ -32,7 +32,7 @@ const PatientBanner: FC<Props> = ({ patient }) => {
   return (
     <StyledPatientBanner deceased={deceased}>
       <PrimaryInformation patient={patient} deceased={deceased} />
-      <SecondaryInformation patient={patient} />
+      <SecondaryInformation patient={patient} patientGroups={patientGroups} />
     </StyledPatientBanner>
   )
 }
@@ -43,6 +43,7 @@ interface StyledPatientBannerProps {
 
 interface Props {
   patient: Patient | undefined
+  patientGroups?: Group[]
 }
 
 export default PatientBanner

--- a/components/clinical/patient-banner/src/molecules/secondary-info.tsx
+++ b/components/clinical/patient-banner/src/molecules/secondary-info.tsx
@@ -22,8 +22,10 @@ const StyledSecondaryInformation = styled.div`
 const SecondaryInformation: FC<Props> = ({ patient, patientGroups }) => (
   <StyledSecondaryInformation>
     <Address patient={patient} />
-    {patientGroups && <PedNumber patientGroups={patientGroups} />}
-    <PasNumber patient={patient} />
+    <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'start', flexDirection: 'row' }}>
+      {patientGroups && <PedNumber patientGroups={patientGroups} style={{ marginLeft: '0.5rem' }} />}
+      <PasNumber patient={patient} style={{ marginLeft: '0.5rem' }} />
+    </div>
   </StyledSecondaryInformation>
 )
 

--- a/components/clinical/patient-banner/src/molecules/secondary-info.tsx
+++ b/components/clinical/patient-banner/src/molecules/secondary-info.tsx
@@ -1,10 +1,11 @@
 import { FC } from 'react'
 import styled from '@emotion/styled'
-import { Patient } from '@ltht-react/types'
+import { Group, Patient } from '@ltht-react/types'
 import { TABLET_MINIMUM_MEDIA_QUERY } from '@ltht-react/styles'
 
 import Address from '../atoms/address'
 import PasNumber from '../atoms/pas-number'
+import PedNumber from '../atoms/ped-number'
 
 const StyledSecondaryInformation = styled.div`
   display: none;
@@ -18,15 +19,17 @@ const StyledSecondaryInformation = styled.div`
   }
 `
 
-const SecondaryInformation: FC<Props> = ({ patient }) => (
+const SecondaryInformation: FC<Props> = ({ patient, patientGroups }) => (
   <StyledSecondaryInformation>
     <Address patient={patient} />
+    {patientGroups && <PedNumber patientGroups={patientGroups} />}
     <PasNumber patient={patient} />
   </StyledSecondaryInformation>
 )
 
 interface Props {
   patient: Patient | undefined
+  patientGroups?: Group[]
 }
 
 export default SecondaryInformation

--- a/packages/storybook/src/clinical/organisms/patient-banner/patient-banner.fixtures.ts
+++ b/packages/storybook/src/clinical/organisms/patient-banner/patient-banner.fixtures.ts
@@ -1,5 +1,7 @@
 import {
   Patient,
+  Group,
+  GroupType,
   AddressUseCode,
   Metadata,
   AddressTypeCode,
@@ -84,6 +86,12 @@ const AlivePatient: Patient = {
     },
   ],
 }
+
+const groupsIncludingPedigreeGroup: Group[] = [
+  { id: 'PED048164', actual: true, metadata: mockMetadata, type: GroupType.Person },
+  { id: 'ZZZ123456', actual: true, metadata: mockMetadata, type: GroupType.Person },
+  { id: 'XXX123456', actual: true, metadata: mockMetadata, type: GroupType.Person },
+]
 
 const DeceasedPatient: Patient = {
   id: '829ca260-67e0-e357-b2c7-115087226fg2|patient',
@@ -295,4 +303,10 @@ const DeceasedPatientWithoutBoolean: Patient = {
   ],
 }
 
-export { AlivePatient, DeceasedPatient, DeceasedPatientWithoutDate, DeceasedPatientWithoutBoolean }
+export {
+  AlivePatient,
+  DeceasedPatient,
+  DeceasedPatientWithoutDate,
+  DeceasedPatientWithoutBoolean,
+  groupsIncludingPedigreeGroup,
+}

--- a/packages/storybook/src/clinical/organisms/patient-banner/patient-banner.stories.tsx
+++ b/packages/storybook/src/clinical/organisms/patient-banner/patient-banner.stories.tsx
@@ -6,9 +6,13 @@ import {
   DeceasedPatient,
   DeceasedPatientWithoutDate,
   DeceasedPatientWithoutBoolean,
+  groupsIncludingPedigreeGroup,
 } from './patient-banner.fixtures'
 
 export const Alive: Story = () => <PatientBanner patient={AlivePatient} />
+export const WithPedigreeNumber: Story = () => (
+  <PatientBanner patient={AlivePatient} patientGroups={groupsIncludingPedigreeGroup} />
+)
 export const Deceased: Story = () => <PatientBanner patient={DeceasedPatient} />
 export const DeceasedWithoutDate: Story = () => <PatientBanner patient={DeceasedPatientWithoutDate} />
 export const DeceasedWithoutBoolean: Story = () => <PatientBanner patient={DeceasedPatientWithoutBoolean} />

--- a/packages/storybook/src/clinical/organisms/patient-banner/patient-banner.test.tsx
+++ b/packages/storybook/src/clinical/organisms/patient-banner/patient-banner.test.tsx
@@ -1,10 +1,17 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 
 import PatientBanner from '@ltht-react/patient-banner'
-import { DeceasedPatient } from './patient-banner.fixtures'
+import { AlivePatient, DeceasedPatient, groupsIncludingPedigreeGroup } from './patient-banner.fixtures'
 
 describe('Patient Banner', () => {
   it('Renders', () => {
     render(<PatientBanner patient={DeceasedPatient} />)
+  })
+
+  it('Shows Pedigree Number if one is provided', () => {
+    render(<PatientBanner patient={AlivePatient} patientGroups={groupsIncludingPedigreeGroup} />)
+
+    expect(screen.getByText('Ped No.')).toBeInTheDocument()
+    expect(screen.getByText('PED048164')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
The Shire team want the Pedigree Number to be shown in the patient banner (IFF present, and IFF the user has the clinical genetics permission). 

This PR expands the PatientBanner component to accept an optional list of patient groups. If a pedigree group is among them then the number will be displayed as secondary information. 

I'm not 100% sure if the positioning is right - but I've no better ideas. By default it's spacing all secondary information out evenly as per the below screenshots:
![PatientBannerWIthPedNumber](https://user-images.githubusercontent.com/63285990/223431804-f5b02777-f009-4952-b3d9-aa0c399fb6a5.jpg)
![PatientBannerCss](https://user-images.githubusercontent.com/63285990/223431816-d692db35-5c06-4acb-9dae-8d9cabcdafb5.jpg)
