### PR TITLE
Timeline filtering - Fix issue when select option has no value

### DIFF
--- a/components/clinical/timeline/src/organisms/timeline.tsx
+++ b/components/clinical/timeline/src/organisms/timeline.tsx
@@ -214,11 +214,11 @@ const Timeline: FC<IProps> = ({ timelineItems, domainResourceType, filters, onFi
 
   let position = 0
 
-  const handleFilterChange = (key: number, filter?: string) => {
+  const handleFilterChange = (key: number, filter: ITimelineFilter, value?: string) => {
     const newActiveFilters = { ...activeFilters }
 
-    if (filter && filter.length > 0) {
-      newActiveFilters[key] = filter
+    if (value && value.length > 0 && filter.options.some((x) => x.value === value)) {
+      newActiveFilters[key] = value
     } else {
       delete newActiveFilters[key]
     }
@@ -237,7 +237,7 @@ const Timeline: FC<IProps> = ({ timelineItems, domainResourceType, filters, onFi
               <Select
                 id={`${filter.label}-${key}`}
                 options={filter.options}
-                onChange={(e) => handleFilterChange(key, e.target.value)}
+                onChange={(e) => handleFilterChange(key, filter, e.target.value)}
               />
             </StyledFilter>
           ))}

--- a/packages/storybook/src/clinical/organisms/timeline/timeline.stories.tsx
+++ b/packages/storybook/src/clinical/organisms/timeline/timeline.stories.tsx
@@ -236,7 +236,7 @@ export const TimelineWithFilters: Story = () => {
     {
       label: 'Care plan',
       options: [
-        { label: '', value: undefined },
+        { label: 'All', value: undefined },
         {
           label: 'Pneumonia',
           value: 'domain:careplan:definitionseriesid:9f4e2790-d0b7-a891-5d51-5f35b0e58228',

--- a/packages/storybook/src/clinical/organisms/timeline/timeline.test.tsx
+++ b/packages/storybook/src/clinical/organisms/timeline/timeline.test.tsx
@@ -212,107 +212,153 @@ it('Questionnaire uses questionnaire.title as backup title', () => {
   expect(screen.queryAllByText(backupTitle)).toHaveLength(1)
 })
 
-it('will show filters if available', async () => {
-  const timelineItems: ITimelineItem[] = [
-    {
-      domainResource: TitleResponse,
-      buttonState: 'selectable-button',
-    },
-  ]
+describe('Filtering', () => {
+  it('will show filters if available', async () => {
+    const timelineItems: ITimelineItem[] = [
+      {
+        domainResource: TitleResponse,
+        buttonState: 'selectable-button',
+      },
+    ]
 
-  const filters: ITimelineFilter[] = [
-    {
-      label: 'Care plan',
-      options: [
-        { label: '', value: undefined },
-        {
-          label: 'Pneumonia',
-          value: 'domain:careplan:definitionseriesid:9f4e2790-d0b7-a891-5d51-5f35b0e58228',
-        },
-      ],
-    },
-    {
-      label: 'User',
-      options: [
-        { label: '', value: undefined },
-        {
-          label: 'Bob',
-          value: 'domain:user:some-random-user-guid',
-        },
-      ],
-    },
-  ]
+    const filters: ITimelineFilter[] = [
+      {
+        label: 'Care plan',
+        options: [
+          { label: '', value: undefined },
+          {
+            label: 'Pneumonia',
+            value: 'domain:careplan:definitionseriesid:9f4e2790-d0b7-a891-5d51-5f35b0e58228',
+          },
+        ],
+      },
+      {
+        label: 'User',
+        options: [
+          { label: '', value: undefined },
+          {
+            label: 'Bob',
+            value: 'domain:user:some-random-user-guid',
+          },
+        ],
+      },
+    ]
 
-  render(
-    <Timeline
-      timelineItems={timelineItems}
-      domainResourceType={TimelineDomainResourceType.QuestionnaireResponse}
-      filters={filters}
-    />
-  )
+    render(
+      <Timeline
+        timelineItems={timelineItems}
+        domainResourceType={TimelineDomainResourceType.QuestionnaireResponse}
+        filters={filters}
+      />
+    )
 
-  await screen.findByLabelText(/Care plan:/)
-  await screen.findByLabelText(/User:/)
-})
+    await screen.findByLabelText(/Care plan:/)
+    await screen.findByLabelText(/User:/)
+  })
 
-it('will call back with selected filters when a value is changed', async () => {
-  const timelineItems: ITimelineItem[] = [
-    {
-      domainResource: TitleResponse,
-      buttonState: 'selectable-button',
-    },
-  ]
+  it('will call back with selected filters when a value is changed', async () => {
+    const timelineItems: ITimelineItem[] = [
+      {
+        domainResource: TitleResponse,
+        buttonState: 'selectable-button',
+      },
+    ]
 
-  const filters: ITimelineFilter[] = [
-    {
-      label: 'Care plan',
-      options: [
-        { label: '', value: undefined },
-        {
-          label: 'Pneumonia',
-          value: 'domain:careplan:definitionseriesid:9f4e2790-d0b7-a891-5d51-5f35b0e58228',
-        },
-      ],
-    },
-    {
-      label: 'User',
-      options: [
-        { label: '', value: undefined },
-        {
-          label: 'Bob',
-          value: 'domain:user:some-random-user-guid',
-        },
-      ],
-    },
-  ]
+    const filters: ITimelineFilter[] = [
+      {
+        label: 'Care plan',
+        options: [
+          { label: '', value: undefined },
+          {
+            label: 'Pneumonia',
+            value: 'domain:careplan:definitionseriesid:9f4e2790-d0b7-a891-5d51-5f35b0e58228',
+          },
+        ],
+      },
+      {
+        label: 'User',
+        options: [
+          { label: '', value: undefined },
+          {
+            label: 'Bob',
+            value: 'domain:user:some-random-user-guid',
+          },
+        ],
+      },
+    ]
 
-  const handleFilterChangeMock = jest.fn()
+    const handleFilterChangeMock = jest.fn()
 
-  render(
-    <Timeline
-      timelineItems={timelineItems}
-      domainResourceType={TimelineDomainResourceType.QuestionnaireResponse}
-      filters={filters}
-      onFilterChange={handleFilterChangeMock}
-    />
-  )
-  const carePlanFilter = await screen.findByLabelText(/Care plan:/)
-  const userFilter = await screen.findByLabelText(/User:/)
+    render(
+      <Timeline
+        timelineItems={timelineItems}
+        domainResourceType={TimelineDomainResourceType.QuestionnaireResponse}
+        filters={filters}
+        onFilterChange={handleFilterChangeMock}
+      />
+    )
+    const carePlanFilter = await screen.findByLabelText(/Care plan:/)
+    const userFilter = await screen.findByLabelText(/User:/)
 
-  userEvent.selectOptions(carePlanFilter, 'domain:careplan:definitionseriesid:9f4e2790-d0b7-a891-5d51-5f35b0e58228')
+    userEvent.selectOptions(carePlanFilter, 'domain:careplan:definitionseriesid:9f4e2790-d0b7-a891-5d51-5f35b0e58228')
 
-  expect(handleFilterChangeMock).toHaveBeenLastCalledWith([
-    'domain:careplan:definitionseriesid:9f4e2790-d0b7-a891-5d51-5f35b0e58228',
-  ])
+    expect(handleFilterChangeMock).toHaveBeenLastCalledWith([
+      'domain:careplan:definitionseriesid:9f4e2790-d0b7-a891-5d51-5f35b0e58228',
+    ])
 
-  userEvent.selectOptions(userFilter, 'domain:user:some-random-user-guid')
+    userEvent.selectOptions(userFilter, 'domain:user:some-random-user-guid')
 
-  expect(handleFilterChangeMock).toHaveBeenLastCalledWith([
-    'domain:careplan:definitionseriesid:9f4e2790-d0b7-a891-5d51-5f35b0e58228',
-    'domain:user:some-random-user-guid',
-  ])
+    expect(handleFilterChangeMock).toHaveBeenLastCalledWith([
+      'domain:careplan:definitionseriesid:9f4e2790-d0b7-a891-5d51-5f35b0e58228',
+      'domain:user:some-random-user-guid',
+    ])
 
-  userEvent.selectOptions(carePlanFilter, '')
+    userEvent.selectOptions(carePlanFilter, '')
 
-  expect(handleFilterChangeMock).toHaveBeenLastCalledWith(['domain:user:some-random-user-guid'])
+    expect(handleFilterChangeMock).toHaveBeenLastCalledWith(['domain:user:some-random-user-guid'])
+  })
+
+  it('will not return the label if value is undefined', async () => {
+    const timelineItems: ITimelineItem[] = [
+      {
+        domainResource: TitleResponse,
+        buttonState: 'selectable-button',
+      },
+    ]
+
+    const filters: ITimelineFilter[] = [
+      {
+        label: 'Care plan',
+        options: [
+          { label: 'All', value: undefined },
+          {
+            label: 'Pneumonia',
+            value: 'domain:careplan:definitionseriesid:9f4e2790-d0b7-a891-5d51-5f35b0e58228',
+          },
+        ],
+      },
+    ]
+
+    const handleFilterChangeMock = jest.fn()
+
+    render(
+      <Timeline
+        timelineItems={timelineItems}
+        domainResourceType={TimelineDomainResourceType.QuestionnaireResponse}
+        filters={filters}
+        onFilterChange={handleFilterChangeMock}
+      />
+    )
+    const carePlanFilter = await screen.findByLabelText(/Care plan:/)
+
+    userEvent.selectOptions(carePlanFilter, 'domain:careplan:definitionseriesid:9f4e2790-d0b7-a891-5d51-5f35b0e58228')
+
+    expect(handleFilterChangeMock).toHaveBeenLastCalledWith([
+      'domain:careplan:definitionseriesid:9f4e2790-d0b7-a891-5d51-5f35b0e58228',
+    ])
+
+    userEvent.selectOptions(carePlanFilter, 'All')
+
+    expect(handleFilterChangeMock).toHaveBeenLastCalledWith([])
+  })
 })


### PR DESCRIPTION
If you have a filter option that does not have a value (for example a default option, see [unit test](https://github.com/ltht-epr/ltht-react/blob/f70a074f5d0034b4ce08601f2771c176a31e6e7f/packages/storybook/src/clinical/organisms/timeline/timeline.test.tsx#L321)). Some browsers, and possibly even the w3c specification will return the label instead. We effectively want it to remove the selected filter instead.

This does that.