### PR TITLE
Render QuestionText same as QuestionString

### DIFF
--- a/components/clinical/questionnaire/src/molecules/question-block.tsx
+++ b/components/clinical/questionnaire/src/molecules/question-block.tsx
@@ -70,6 +70,7 @@ const generateAnswer = (
         isFullWidth: false,
       }
     case QuestionnaireItemTypeCode.QuestionString:
+    case QuestionnaireItemTypeCode.QuestionText:
       return {
         Answer: (
           <NestedListDetail term={question || '-'} showIfEmpty={showIfEmpty}>


### PR DESCRIPTION
They're the same type of data, only difference being that the FHIR spec suggests QuestionText should be used for responses that could be quite long / wordy