### PR TITLE
Add missing param for removing a favourite plan definition

### DIFF
--- a/packages/types/src/atoms/graphql-types.ts
+++ b/packages/types/src/atoms/graphql-types.ts
@@ -1537,6 +1537,7 @@ export type EhrMutationPauseCarePlanArgs = {
 
 /** Mutations of the LTHT EHR. */
 export type EhrMutationRemovePlanDefinitionFavouriteArgs = {
+  planDefinitionId: Scalars['Guid'];
   planDefinitionSeriesId: Scalars['Guid'];
 };
 


### PR DESCRIPTION
Missed a param on the GraphQL mutation in the last PR