### PR TITLE
export cellprops type from table molecule

### DIFF
--- a/components/styled/table/src/molecules/table.tsx
+++ b/components/styled/table/src/molecules/table.tsx
@@ -162,4 +162,4 @@ interface TableData {
 }
 
 export default Table
-export { DataEntity, Header, TableData }
+export { DataEntity, CellProps, Header, TableData }


### PR DESCRIPTION
exporting cell props type in order create customised cell tables in ehr-client