### PR TITLE
Identify pedigree groups if they start with LCG rather than PED

### DIFF
--- a/components/clinical/patient-banner/src/atoms/ped-number.tsx
+++ b/components/clinical/patient-banner/src/atoms/ped-number.tsx
@@ -18,7 +18,8 @@ const StyledValue = styled.span`
 `
 
 const PedNumber: FC<Props> = ({ patientGroups, ...rest }) => {
-  const pedGroup = patientGroups.find((pg) => pg.id.startsWith('PED'))
+  // TODO: find a better solkution to this magic string. Endpoint? Pass in front ehr-client?
+  const pedGroup = patientGroups.find((pg) => pg.id.startsWith('LCG'))
 
   if (pedGroup === undefined) {
     return null

--- a/packages/storybook/src/clinical/organisms/patient-banner/patient-banner.fixtures.ts
+++ b/packages/storybook/src/clinical/organisms/patient-banner/patient-banner.fixtures.ts
@@ -88,7 +88,7 @@ const AlivePatient: Patient = {
 }
 
 const groupsIncludingPedigreeGroup: Group[] = [
-  { id: 'PED048164', actual: true, metadata: mockMetadata, type: GroupType.Person },
+  { id: 'LCG048164', actual: true, metadata: mockMetadata, type: GroupType.Person },
   { id: 'ZZZ123456', actual: true, metadata: mockMetadata, type: GroupType.Person },
   { id: 'XXX123456', actual: true, metadata: mockMetadata, type: GroupType.Person },
 ]

--- a/packages/storybook/src/clinical/organisms/patient-banner/patient-banner.test.tsx
+++ b/packages/storybook/src/clinical/organisms/patient-banner/patient-banner.test.tsx
@@ -12,6 +12,6 @@ describe('Patient Banner', () => {
     render(<PatientBanner patient={AlivePatient} patientGroups={groupsIncludingPedigreeGroup} />)
 
     expect(screen.getByText('Ped No.')).toBeInTheDocument()
-    expect(screen.getByText('PED048164')).toBeInTheDocument()
+    expect(screen.getByText('LCG048164')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
I know we're ultimately planning to get this from the codes table in the DB, so will leave this as this for now. 

Not sure what the ideal route is to query the codes table from this repo though...