### PR TITLE
Ehr 24873/make table sorting optional

### DIFF
--- a/components/styled/table/src/molecules/table-component.tsx
+++ b/components/styled/table/src/molecules/table-component.tsx
@@ -1,7 +1,6 @@
 import Icon from '@ltht-react/icon'
 import { flexRender, Header as ReactTableHeader, Table } from '@tanstack/react-table'
 import React, { useMemo, useRef } from 'react'
-import { Axis } from '@ltht-react/types'
 import { calculateStaticColumnOffset } from './table-methods'
 import {
   StyledNextPageButtonContainer,
@@ -14,8 +13,9 @@ import {
 } from './table-styled-components'
 import useDimensionsRef from './useDimensionRef'
 import { CellProps } from './table-cell'
+import { ITableConfig } from './table'
 
-const TableComponent = <T,>({ table, staticColumns, headerAxis }: ITableHeadProps<T>): JSX.Element => {
+const TableComponent = <T,>({ table, staticColumns = 0, headerAxis }: ITableHeadProps<T>): JSX.Element => {
   const firstColumn = useRef(null)
   const secondColumn = useRef(null)
   const tableElement = useRef(null)
@@ -138,10 +138,8 @@ interface ITableSpinnerProps {
   hidden: boolean
 }
 
-interface ITableHeadProps<T> {
+interface ITableHeadProps<T> extends ITableConfig {
   table: Table<T>
-  headerAxis: Axis
-  staticColumns: 0 | 1 | 2
 }
 
 export default TableComponent

--- a/components/styled/table/src/molecules/table.tsx
+++ b/components/styled/table/src/molecules/table.tsx
@@ -8,6 +8,7 @@ import {
   SortingState,
   PaginationState,
   ColumnDef,
+  SortingFn,
 } from '@tanstack/react-table'
 import { Axis } from '@ltht-react/types'
 import { ScrollableContainer } from './table-styled-components'
@@ -29,6 +30,8 @@ const Table: FC<IProps> = ({
   keepPreviousData = false,
   maxHeight,
   maxWidth,
+  enableSorting = true,
+  sortingFunctions = undefined,
 }) => {
   const scrollableDivElement = useRef(null)
   const scrollState = useScrollRef(scrollableDivElement)
@@ -69,6 +72,8 @@ const Table: FC<IProps> = ({
     manualPagination: true,
     onExpandedChange: setExpanded,
     onSortingChange: setSorting,
+    enableSorting,
+    sortingFns: sortingFunctions,
     getSubRows: (row) => row.subRows,
     getCoreRowModel: getCoreRowModel(),
     getExpandedRowModel: getExpandedRowModel(),
@@ -109,10 +114,16 @@ const Table: FC<IProps> = ({
   )
 }
 
-interface IProps extends IPaginationProps, ITableDimensionProps {
+interface IProps extends ITableConfig, IPaginationProps, ITableDimensionProps {
   tableData: TableData
+}
+
+export interface ITableConfig {
   staticColumns?: 0 | 1 | 2
   headerAxis?: Axis
+  enableSorting?: boolean
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sortingFunctions?: Record<string, SortingFn<any>> | undefined
 }
 
 export interface IPaginationProps {

--- a/components/styled/table/src/organisms/generic-table.tsx
+++ b/components/styled/table/src/organisms/generic-table.tsx
@@ -1,5 +1,4 @@
-import { Axis } from '@ltht-react/types'
-import Table, { IPaginationProps, ITableDimensionProps, TableData } from '../molecules/table'
+import Table, { IPaginationProps, ITableDimensionProps, ITableConfig, TableData } from '../molecules/table'
 
 const GenericTable = <TColumn, TRow>({
   columnData,
@@ -25,11 +24,10 @@ const GenericTable = <TColumn, TRow>({
   )
 }
 
-interface IProps<TColumn, TRow> extends IPaginationProps, ITableDimensionProps {
+interface IProps<TColumn, TRow> extends ITableConfig, IPaginationProps, ITableDimensionProps {
   columnData: TColumn
   rowData: TRow
   mapToTableData: (colData: TColumn, rowData: TRow) => TableData
-  headerAxis?: Axis
 }
 
 export default GenericTable

--- a/components/styled/table/src/organisms/questionnaire-table.tsx
+++ b/components/styled/table/src/organisms/questionnaire-table.tsx
@@ -1,7 +1,7 @@
-import { QuestionnaireResponse, Axis, Questionnaire } from '@ltht-react/types'
+import { QuestionnaireResponse, Questionnaire } from '@ltht-react/types'
 import { FC, useMemo } from 'react'
 import Icon from '@ltht-react/icon'
-import Table, { IPaginationProps, ITableDimensionProps } from '../molecules/table'
+import Table, { IPaginationProps, ITableDimensionProps, ITableConfig } from '../molecules/table'
 import mapQuestionnaireDefinitionAndResponsesToTableData, {
   AdminActionsForQuestionnaire,
 } from './questionnaire-table-methods'
@@ -46,12 +46,10 @@ const QuestionnaireTable: FC<IProps> = ({
   )
 }
 
-interface IProps extends IPaginationProps, ITableDimensionProps {
+interface IProps extends ITableConfig, IPaginationProps, ITableDimensionProps {
   definition: Questionnaire
   records: QuestionnaireResponse[]
-  headerAxis?: Axis
   adminActions?: AdminActionsForQuestionnaire[]
-  staticColumns?: 0 | 1 | 2
 }
 
 export default QuestionnaireTable

--- a/packages/storybook/src/ui/molecules/table/table.stories.tsx
+++ b/packages/storybook/src/ui/molecules/table/table.stories.tsx
@@ -12,6 +12,8 @@ import {
 
 export const SimpleTable: Story = () => <Table tableData={mockTableData} />
 
+export const TableWithSortingDisabled: Story = () => <Table tableData={mockTableData} enableSorting={false} />
+
 export const TableWithSubheaders: Story = () => <Table tableData={mockTableDataWithSubheaders} />
 
 export const TableWithSubrows: Story = () => <Table tableData={mockTableDataWithSubrows} />

--- a/packages/storybook/src/ui/organisms/questionnaire-table/questionnaire-table.test.tsx
+++ b/packages/storybook/src/ui/organisms/questionnaire-table/questionnaire-table.test.tsx
@@ -68,6 +68,26 @@ describe('Questionnaire Table (using Fixture data)', () => {
     expect(getTopLeftDataCell()).toHaveTextContent('Average BASFI Score')
   })
 
+  it('Does not sort the table if sorting is disabled', () => {
+    render(
+      <QuestionnaireTable
+        definition={summaryDefinition}
+        records={summaryRecordsList}
+        headerAxis="y"
+        enableSorting={false}
+      />
+    )
+
+    const getTopLeftDataCell = () => within(screen.getAllByRole('row')[1]).getAllByRole('cell')[1]
+
+    expect(getTopLeftDataCell()).toHaveTextContent('Score')
+
+    userEvent.click(screen.getByText('17-Feb-2022 17:23'))
+    userEvent.click(screen.getByText('17-Feb-2022 17:23'))
+
+    expect(getTopLeftDataCell()).toHaveTextContent('Score')
+  })
+
   it('Sorts the table if the lowest level of subheaders are clicked in horizontal mode', () => {
     render(<QuestionnaireTable definition={summaryDefinition} records={summaryRecordsList} headerAxis="x" />)
 


### PR DESCRIPTION
Expose a boolean toggle to disable automatic header sorting.
Also expose control of sorting methods override