### PR TITLE
Top level signatory parameter - type gen

### DIFF
--- a/packages/types/src/atoms/graphql-types.ts
+++ b/packages/types/src/atoms/graphql-types.ts
@@ -605,7 +605,6 @@ export type CarePlanDocumentInput = {
   activities?: Maybe<Array<Maybe<CarePlanActivityInput>>>;
   carePlanId: Scalars['Guid'];
   goalEvaluations?: Maybe<Array<Maybe<CarePlanGoalEvaluationInput>>>;
-  signatories?: Maybe<Array<SignatoryInputType>>;
 };
 
 /** Goal evaluations from the care plan */
@@ -643,8 +642,6 @@ export type CarePlanModelInput = {
   planDefinitionSeriesId?: Maybe<Scalars['String']>;
   reasonCode?: Maybe<Scalars['String']>;
   reasonText?: Maybe<Scalars['String']>;
-  requestCountersignature?: Maybe<Scalars['Boolean']>;
-  signatories?: Maybe<Array<SignatoryInputType>>;
 };
 
 export enum CarePlanStatusCode {
@@ -1542,6 +1539,7 @@ export type EhrMutation = {
 export type EhrMutationAddCarePlanArgs = {
   model: CarePlanModelInput;
   patientGuid: Scalars['Guid'];
+  signatories?: Maybe<Array<SignatoryInputType>>;
   template: Scalars['String'];
 };
 


### PR DESCRIPTION
Standardise signatories mutation input so that:
- It is always passed as a parameter at the root level
- It is removed from any complex mutation models
- Remove explicit flag for `requestCountersignature` - instead infer it from the signatories (apart from in document care plan, where each individual document can be marked separately as requiring countersignature)