### PR TITLE
EHR-24377 Prevent clicks on the ActionMenu from bubbling up

### DIFF
--- a/components/styled/menu/src/molecules/action-menu.tsx
+++ b/components/styled/menu/src/molecules/action-menu.tsx
@@ -152,7 +152,8 @@ const ActionMenu: FC<IProps> = ({
                   <StyledListItem
                     role="menuitem"
                     key={`menu-action-${idx}`}
-                    onClick={() => {
+                    onClick={(e) => {
+                      e.stopPropagation()
                       menuButtonClickHandler()
                       action.clickHandler()
                     }}


### PR DESCRIPTION
Action menu clicks are bubbling up in the task dashboard causing the primary click handler to fire when it's not required.