### PR TITLE
EHR-27471 Add an option to forcibly refresh iframe source on rendering of eForm

### DIFF
--- a/components/clinical/eForm/src/index.tsx
+++ b/components/clinical/eForm/src/index.tsx
@@ -54,7 +54,7 @@ const EForm: FC<Props> = ({ url, callback, forceRefresh = false, ...rest }) => {
 
   return (
     <StyledIframe {...rest}>
-      <iframe ref={iframeRef} src={url} title="eForm" data-iframe-key={iframeKey} />
+      <iframe key={iframeKey} ref={iframeRef} src={url} title="eForm" data-iframe-key={iframeKey} />
     </StyledIframe>
   )
 }

--- a/components/clinical/eForm/src/index.tsx
+++ b/components/clinical/eForm/src/index.tsx
@@ -1,8 +1,7 @@
-import { useLayoutEffect, HTMLAttributes, FC, useRef } from 'react'
+import { useLayoutEffect, HTMLAttributes, FC, useRef, useState } from 'react'
 import styled from '@emotion/styled'
 
 import { CSS_RESET, EFORM_BACKGROUND_COLOUR } from '@ltht-react/styles'
-import { useState } from 'react'
 
 const StyledIframe = styled.div`
   ${CSS_RESET}

--- a/components/clinical/eForm/src/index.tsx
+++ b/components/clinical/eForm/src/index.tsx
@@ -1,5 +1,4 @@
 import { FC, HTMLAttributes, useLayoutEffect, useRef, useState } from 'react'
-
 import styled from '@emotion/styled'
 import { CSS_RESET, EFORM_BACKGROUND_COLOUR } from '@ltht-react/styles'
 

--- a/components/clinical/eForm/src/index.tsx
+++ b/components/clinical/eForm/src/index.tsx
@@ -1,7 +1,8 @@
-import { useLayoutEffect, HTMLAttributes, FC } from 'react'
+import { useLayoutEffect, HTMLAttributes, FC, useRef } from 'react'
 import styled from '@emotion/styled'
 
 import { CSS_RESET, EFORM_BACKGROUND_COLOUR } from '@ltht-react/styles'
+import { useState } from 'react'
 
 const StyledIframe = styled.div`
   ${CSS_RESET}
@@ -22,7 +23,10 @@ const StyledIframe = styled.div`
   }
 `
 
-const EForm: FC<Props> = ({ url, callback, ...rest }) => {
+const EForm: FC<Props> = ({ url, callback, forceRefresh, ...rest }) => {
+  const [iframeKey, setIframeKey] = useState(0)
+  const iframeRef = useRef<HTMLIFrameElement | null>(null)
+
   useLayoutEffect(() => {
     function handleEvent(event: MessageEvent): void {
       switch (event.data.eventType) {
@@ -44,9 +48,15 @@ const EForm: FC<Props> = ({ url, callback, ...rest }) => {
     }
   }, [callback])
 
+  useLayoutEffect(() => {
+    if (forceRefresh && iframeRef.current) {
+      setIframeKey((prevKey: number) => prevKey + 1)
+    }
+  }, [forceRefresh])
+
   return (
     <StyledIframe {...rest}>
-      <iframe src={url} title="eForm" />
+      <iframe key={iframeKey} ref={iframeRef} src={url} title="eForm" />
     </StyledIframe>
   )
 }
@@ -59,6 +69,7 @@ interface Callback {
 interface Props extends HTMLAttributes<HTMLDivElement> {
   url: string
   callback?: Callback
+  forceRefresh?: boolean
 }
 
 export default EForm

--- a/components/clinical/eForm/src/index.tsx
+++ b/components/clinical/eForm/src/index.tsx
@@ -1,6 +1,6 @@
-import { useLayoutEffect, HTMLAttributes, FC, useRef, useState } from 'react'
-import styled from '@emotion/styled'
+import { FC, HTMLAttributes, useLayoutEffect, useRef, useState } from 'react'
 
+import styled from '@emotion/styled'
 import { CSS_RESET, EFORM_BACKGROUND_COLOUR } from '@ltht-react/styles'
 
 const StyledIframe = styled.div`
@@ -22,7 +22,7 @@ const StyledIframe = styled.div`
   }
 `
 
-const EForm: FC<Props> = ({ url, callback, forceRefresh, ...rest }) => {
+const EForm: FC<Props> = ({ url, callback, forceRefresh = false, ...rest }) => {
   const [iframeKey, setIframeKey] = useState(0)
   const iframeRef = useRef<HTMLIFrameElement | null>(null)
 
@@ -55,7 +55,7 @@ const EForm: FC<Props> = ({ url, callback, forceRefresh, ...rest }) => {
 
   return (
     <StyledIframe {...rest}>
-      <iframe key={iframeKey} ref={iframeRef} src={url} title="eForm" />
+      <iframe key={iframeKey} ref={iframeRef} src={url} title="eForm" data-iframe-key={iframeKey} />
     </StyledIframe>
   )
 }

--- a/components/clinical/eForm/src/index.tsx
+++ b/components/clinical/eForm/src/index.tsx
@@ -54,7 +54,7 @@ const EForm: FC<Props> = ({ url, callback, forceRefresh = false, ...rest }) => {
 
   return (
     <StyledIframe {...rest}>
-      <iframe key={iframeKey} ref={iframeRef} src={url} title="eForm" data-iframe-key={iframeKey} />
+      <iframe ref={iframeRef} src={url} title="eForm" data-iframe-key={iframeKey} />
     </StyledIframe>
   )
 }

--- a/packages/storybook/src/clinical/organisms/eForm/eForm.test.tsx
+++ b/packages/storybook/src/clinical/organisms/eForm/eForm.test.tsx
@@ -5,12 +5,10 @@ describe('eForm', () => {
   it('Increments iframeKey to trigger iframe refresh, when forceRefresh is true', () => {
     const mockCallback = jest.fn()
 
-    const { rerender } = render(
-      <EForm url="https://www.wikipedia.org/" callback={{ name: 'test', handler: mockCallback }} />
-    )
+    const { rerender } = render(<EForm url="https://example.com/" callback={{ name: 'test', handler: mockCallback }} />)
     const initialIframeKey = screen.getByTitle('eForm').getAttribute('data-iframe-key')
 
-    rerender(<EForm url="https://www.wikipedia.org/" callback={{ name: 'test', handler: mockCallback }} forceRefresh />)
+    rerender(<EForm url="https://example.com/" callback={{ name: 'test', handler: mockCallback }} forceRefresh />)
     const updatedIframeKey = screen.getByTitle('eForm').getAttribute('data-iframe-key')
 
     expect(updatedIframeKey).not.toBe(initialIframeKey)
@@ -19,12 +17,10 @@ describe('eForm', () => {
   it('Does not increment iframeKey, when forceRefresh is false', () => {
     const mockCallback = jest.fn()
 
-    const { rerender } = render(
-      <EForm url="https://www.wikipedia.org/" callback={{ name: 'test', handler: mockCallback }} />
-    )
+    const { rerender } = render(<EForm url="https://example.com/" callback={{ name: 'test', handler: mockCallback }} />)
     const initialIframeKey = screen.getByTitle('eForm').getAttribute('data-iframe-key')
 
-    rerender(<EForm url="https://www.wikipedia.org/" callback={{ name: 'test', handler: mockCallback }} />)
+    rerender(<EForm url="https://example.com/" callback={{ name: 'test', handler: mockCallback }} />)
     const updatedIframeKey = screen.getByTitle('eForm').getAttribute('data-iframe-key')
 
     expect(updatedIframeKey).toBe(initialIframeKey)

--- a/packages/storybook/src/clinical/organisms/eForm/eForm.test.tsx
+++ b/packages/storybook/src/clinical/organisms/eForm/eForm.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react'
+import EForm from '@ltht-react/eform/src'
+
+describe('eForm', () => {
+  it('Increments iframeKey to trigger iframe refresh, when forceRefresh is true', () => {
+    const mockCallback = jest.fn()
+
+    const { rerender } = render(
+      <EForm url="https://www.wikipedia.org/" callback={{ name: 'test', handler: mockCallback }} />
+    )
+    const initialIframeKey = screen.getByTitle('eForm').getAttribute('data-iframe-key')
+
+    rerender(<EForm url="https://www.wikipedia.org/" callback={{ name: 'test', handler: mockCallback }} forceRefresh />)
+    const updatedIframeKey = screen.getByTitle('eForm').getAttribute('data-iframe-key')
+
+    expect(updatedIframeKey).not.toBe(initialIframeKey)
+  })
+
+  it('Does not increment iframeKey, when forceRefresh is false', () => {
+    const mockCallback = jest.fn()
+
+    const { rerender } = render(
+      <EForm url="https://www.wikipedia.org/" callback={{ name: 'test', handler: mockCallback }} />
+    )
+    const initialIframeKey = screen.getByTitle('eForm').getAttribute('data-iframe-key')
+
+    rerender(<EForm url="https://www.wikipedia.org/" callback={{ name: 'test', handler: mockCallback }} />)
+    const updatedIframeKey = screen.getByTitle('eForm').getAttribute('data-iframe-key')
+
+    expect(updatedIframeKey).toBe(initialIframeKey)
+  })
+})


### PR DESCRIPTION
This PR is to add an option for the eForm iframe to forcibly refresh on rendering, if the forceRefresh flag is set to true. 

This addresses an issue on the Diagnosis dashboard where the iframe is not refreshed, even if you switch between the level one and level two forms when editing a diagnosis, as level one forms and their extended level two form share a setGuid so the URL within forms4health remains unchanged despite the fact they are different forms.

The BA on the project decided they would rather forcibly refresh and lose data entered in the level one form to edit a level two form, as opposed to hiding the 'Edit' and 'Add Detail' buttons when the user opens the forms4health edit view.

The solution here comes from the logic in these two solutions online: 
https://neemzy.org/articles/forcing-an-iframe-to-rerender-with-react
https://stackoverflow.com/questions/48830316/how-do-you-reload-an-iframe-with-reactjs