### PR TITLE
added new components specific to admissionsummary period

### DIFF
--- a/components/clinical/hospital-stay-summary/src/atoms/admission-period-summary.tsx
+++ b/components/clinical/hospital-stay-summary/src/atoms/admission-period-summary.tsx
@@ -1,0 +1,23 @@
+import { PeriodSummary } from '@ltht-react/type-summary'
+import { Maybe, PartialDateTime, PartialDateTimeKindCode, Period } from '@ltht-react/types'
+import { HTMLAttributes } from 'react'
+
+const AdmissionPeriodSummary = ({ period, ...rest }: Props) => {
+  if (!period) return null
+
+  const modifiedPeriod = {
+    ...period,
+    start: changePartialDateTimeKindCode(period.start, PartialDateTimeKindCode.Date),
+    end: changePartialDateTimeKindCode(period.end, PartialDateTimeKindCode.Date),
+  }
+
+  return <PeriodSummary period={modifiedPeriod} {...rest} />
+}
+
+const changePartialDateTimeKindCode = (date?: Maybe<PartialDateTime>, kind?: PartialDateTimeKindCode) =>
+  date ? { ...date, kind: kind ?? PartialDateTimeKindCode.DateTime } : date
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+  period?: Period | null
+}
+export default AdmissionPeriodSummary

--- a/components/clinical/hospital-stay-summary/src/molecules/admission-redacted.tsx
+++ b/components/clinical/hospital-stay-summary/src/molecules/admission-redacted.tsx
@@ -1,0 +1,35 @@
+import { HTMLAttributes, FC } from 'react'
+import styled from '@emotion/styled'
+
+import { Encounter } from '@ltht-react/types'
+import { RedactedDescription } from '@ltht-react/type-summary'
+import AdmissionPeriodSummary from '../atoms/admission-period-summary'
+
+const StyledRedacted = styled.div`
+  display: flex;
+`
+const StyledDate = styled.div`
+  flex: 1;
+  text-align: left;
+`
+const StyledDescription = styled.div`
+  flex: 1;
+  text-align: right;
+`
+
+const AdmissionRedacted: FC<Props> = ({ admission, ...rest }) => (
+  <StyledRedacted {...rest}>
+    <StyledDate>
+      <AdmissionPeriodSummary period={admission.period} />
+    </StyledDate>
+    <StyledDescription>
+      <RedactedDescription />
+    </StyledDescription>
+  </StyledRedacted>
+)
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+  admission: Encounter
+}
+
+export default AdmissionRedacted

--- a/components/clinical/hospital-stay-summary/src/organisms/admission-summary.tsx
+++ b/components/clinical/hospital-stay-summary/src/organisms/admission-summary.tsx
@@ -2,13 +2,13 @@ import { HTMLAttributes, FC } from 'react'
 import styled from '@emotion/styled'
 
 import { Encounter, EncounterStatusCode, Maybe } from '@ltht-react/types'
-import { PeriodSummary } from '@ltht-react/type-summary'
 
 import { BANNER_COLOURS } from '@ltht-react/styles'
 import ServiceProvider from '../atoms/hospital-stay-service-provider'
 import Description from '../atoms/hospital-stay-description'
-import Redacted from '../molecules/hospital-stay-redacted'
 import AdmissionLengthOfStay from '../atoms/admission-length-of-stay'
+import AdmissionPeriodSummary from '../atoms/admission-period-summary'
+import AdmissionRedacted from '../molecules/admission-redacted'
 
 const StyledSummary = styled.div<IStyledSummaryProps>`
   display: flex;
@@ -35,13 +35,13 @@ const StyledService = styled.div`
 
 const AdmissionSummary: FC<Props> = ({ admission, ...rest }) => {
   if (admission.metadata.isRedacted) {
-    return <Redacted hospitalStay={admission} {...rest} />
+    return <AdmissionRedacted admission={admission} {...rest} />
   }
 
   return (
     <StyledSummary {...rest} status={admission.status}>
       <StyledDate>
-        <PeriodSummary period={admission.period} />
+        <AdmissionPeriodSummary period={admission.period} />
         <AdmissionLengthOfStay encounter={admission} />
       </StyledDate>
       {admission.text && (

--- a/packages/storybook/src/clinical/organisms/hospital-stays/hospital-stays.fixtures.ts
+++ b/packages/storybook/src/clinical/organisms/hospital-stays/hospital-stays.fixtures.ts
@@ -201,7 +201,7 @@ const AdmissionOne: Encounter = {
   period: {
     start: {
       value: '2018-09-24T13:28:00+00:00',
-      kind: PartialDateTimeKindCode.Date,
+      kind: PartialDateTimeKindCode.DateTime,
     },
     end: null,
   },
@@ -249,11 +249,11 @@ const AdmissionTwo: Encounter = {
   period: {
     start: {
       value: '2017-09-23T13:28:00+00:00',
-      kind: PartialDateTimeKindCode.Date,
+      kind: PartialDateTimeKindCode.DateTime,
     },
     end: {
       value: '2017-09-28T13:28:00+00:00',
-      kind: PartialDateTimeKindCode.Date,
+      kind: PartialDateTimeKindCode.DateTime,
     },
   },
   length: {


### PR DESCRIPTION
- override the period date display to be just date on frontend as we need to keep the kind to DateTime to be used for the detail view