### PR TITLE
Remove unnecessary before content

### DIFF
--- a/components/styled/card/src/atoms/footer.tsx
+++ b/components/styled/card/src/atoms/footer.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled'
 
 const StyledFooter = styled.div`
   padding: 0.75rem 0.75rem 0.75rem 0;
-  margin-left: 0.75rem;
   border-top: 1px solid rgba(0, 0, 0, 0.125);
 `
 

--- a/components/styled/card/src/atoms/list-item.tsx
+++ b/components/styled/card/src/atoms/list-item.tsx
@@ -34,17 +34,6 @@ const StyledListItem = styled.li`
   border-width: 1px 0 0 0;
   background: ${(props: Props): string => background(props)};
 
-  &:before {
-    content: '';
-    position: absolute;
-    border: 1px solid #fff;
-    border-width: 1px 0 0 0;
-    width: 0.75rem;
-    left: 0;
-    top: -1px;
-    bottom: -1px;
-  }
-
   .card__list-item-container {
     flex: 1;
   }


### PR DESCRIPTION
This PR looks to address the odd padding that we see at the left of a list-item in the diagnosis summary meaning the borders don't line up with the edge of the container

![Screenshot from 2024-03-12 17-25-02](https://github.com/ltht-epr/ltht-react/assets/64597574/e6258d0f-5e7d-44a9-84fa-02dcd2052efc)

![Screenshot from 2024-03-12 18-25-55](https://github.com/ltht-epr/ltht-react/assets/64597574/611b105d-93ae-4c63-b289-01ab7962da2a)
