### PR TITLE
Use assertedDate on diagnosis summary instead of onset date

### DIFF
--- a/components/clinical/diagnosis-summary/src/organisms/diagnosis-summary.tsx
+++ b/components/clinical/diagnosis-summary/src/organisms/diagnosis-summary.tsx
@@ -92,7 +92,7 @@ const DiagnosisSummary: FC<Props> = ({
       </StyledDescription>
 
       <StyledDate>
-        <DateSummary enteredInError={enteredInError} datetime={condition?.onset?.dateTime} />
+        <DateSummary enteredInError={enteredInError} datetime={condition?.assertedDate} />
         <OnsetDateEstimated enteredInError={enteredInError} condition={condition} />
         <Status enteredInError={enteredInError} condition={condition} />
       </StyledDate>


### PR DESCRIPTION
 as the latter is no longer mandatory