### PR TITLE
Forward close messages into f4h iframe

### DIFF
--- a/components/clinical/eForm/src/index.tsx
+++ b/components/clinical/eForm/src/index.tsx
@@ -34,6 +34,15 @@ const EForm: FC<Props> = ({ url, callback, checksum = 0, ...rest }) => {
         case 'form-submitted':
           callback?.handler(callback.name, event)
           break
+        case 'close-form':
+          iframeRef.current?.contentWindow?.postMessage(event.data, '*')
+          break
+        case undefined:
+          if (event.data === 'parent:closing') {
+            break
+          }
+          iframeRef.current?.contentWindow?.postMessage(event.data, '*')
+          break
         default:
           break
       }


### PR DESCRIPTION
Web app uses `postMessage` to communicate with the F4H iframe. Primarily to tell it to close the form and show a warning message.

As we migrate into from `web app -> f4h` to `web app -> dashboard -> f4h` we need to maintain this communication.