### PR TITLE
Make instanceGuid an optional param when retrieving countersignature requests

### DIFF
--- a/packages/types/src/atoms/graphql-types.ts
+++ b/packages/types/src/atoms/graphql-types.ts
@@ -1533,7 +1533,7 @@ export type EhrCountersignatureRequestsForDocumentArgs = {
   countersignatureStatuses?: Maybe<Array<Maybe<ClinicalApprovalStatus>>>;
   cursorToken?: Maybe<Scalars['String']>;
   from?: Maybe<Scalars['DateTimeOffset']>;
-  instanceGuid: Scalars['Guid'];
+  instanceGuid?: Maybe<Scalars['Guid']>;
   patientGuid: Scalars['Guid'];
   setGuid: Scalars['Guid'];
   templateName: Scalars['String'];


### PR DESCRIPTION
If not supplied, the API will return the latest instance of the document