### PR TITLE
Fix card footer padding, no use case for left-only lack of padding

### DIFF
--- a/components/styled/card/src/atoms/footer.tsx
+++ b/components/styled/card/src/atoms/footer.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames'
 import styled from '@emotion/styled'
 
 const StyledFooter = styled.div`
-  padding: 0.75rem 0.75rem 0.75rem 0;
+  padding: 0.75rem;
   border-top: 1px solid rgba(0, 0, 0, 0.125);
 `
 


### PR DESCRIPTION
This inconsistent padding benefits no-one, all ehr-client uses in fact fix it to add it back in. Fixing here and removing these other fix cases.