### PR TITLE
EHR-31504 dateOnly view for diagnosis detail

### DIFF
--- a/components/clinical/diagnosis-detail/src/organisms/diagnosis-detail.tsx
+++ b/components/clinical/diagnosis-detail/src/organisms/diagnosis-detail.tsx
@@ -30,7 +30,7 @@ const Seperator = styled.div`
   margin: 1rem 0;
 `
 
-const DiagnosisDetail: FC<Props> = ({ condition, links, viewType = DetailViewType.Compact }) => {
+const DiagnosisDetail: FC<Props> = ({ condition, links, viewType = DetailViewType.Compact, dateOnly = false }) => {
   const onsetDateEstimated = getBooleanExtension(
     condition.extension,
     'https://fhir.leedsth.nhs.uk/ValueSet/diagnosis-onset-date-estimated-1'
@@ -57,7 +57,7 @@ const DiagnosisDetail: FC<Props> = ({ condition, links, viewType = DetailViewTyp
         <StringDetail term="Verification Status" description={condition.verificationStatus?.toString()} />
         <CodeableConceptDetail term="Severity" concept={condition.severity} />
         <AsserterDetail asserter={condition.asserter} />
-        <DatetimeDetail term="Diagnosis Date" datetime={condition.assertedDate} />
+        <DatetimeDetail term="Diagnosis Date" datetime={condition.assertedDate} dateOnly={dateOnly} />
         <DatetimeDetail term="Abatement Date" datetime={condition.abatement?.dateTime} />
         <AnnotationListDetail term="Note(s)" notes={condition.note} />
       </CollapsibleDetailCollection>
@@ -70,6 +70,7 @@ interface Props extends CollapsibleDetailCollectionProps {
   // TODO: Define 'links?' type once code link config implementation has been done
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   links?: any
+  dateOnly?: boolean
 }
 
 export default DiagnosisDetail

--- a/components/clinical/shared/type-detail/src/molecules/datetime-detail.tsx
+++ b/components/clinical/shared/type-detail/src/molecules/datetime-detail.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled'
 
 import { TEXT_COLOURS } from '@ltht-react/styles'
 import { PartialDateTime } from '@ltht-react/types'
-import { partialDateTimeText } from '@ltht-react/utils'
+import { partialDateTimeText, formatPartialDateTimeAsDateOnly } from '@ltht-react/utils'
 import { DetailViewComponent, IDetailViewProps } from '../atoms/detail-view-component'
 import NestedListDetail from './nested-list-detail'
 
@@ -13,8 +13,8 @@ const StyledOnsetEstimated = styled.div`
   display: inline-block;
 `
 
-const DatetimeDetail: DetailViewComponent<IProps> = ({ term, datetime, showIfEmpty, estimated }) => {
-  const dateTimeText = partialDateTimeText(datetime)
+const DatetimeDetail: DetailViewComponent<IProps> = ({ term, datetime, showIfEmpty, estimated, dateOnly }) => {
+  const dateTimeText = dateOnly ? formatPartialDateTimeAsDateOnly(datetime) : partialDateTimeText(datetime)
   if (dateTimeText !== '' || showIfEmpty === true) {
     return (
       <NestedListDetail term={term} showIfEmpty={showIfEmpty}>
@@ -30,6 +30,7 @@ interface IProps extends IDetailViewProps {
   term: string
   datetime?: PartialDateTime | null
   estimated?: boolean | null
+  dateOnly?: boolean
 }
 
 export default DatetimeDetail

--- a/components/clinical/shared/type-summary/src/atoms/date-summary.tsx
+++ b/components/clinical/shared/type-summary/src/atoms/date-summary.tsx
@@ -1,10 +1,9 @@
 import { HTMLAttributes, FC } from 'react'
 import styled from '@emotion/styled'
-import { format, parseISO } from 'date-fns'
 
 import { TEXT_COLOURS } from '@ltht-react/styles'
 import { PartialDateTime } from '@ltht-react/types'
-import { partialDateTimeText } from '@ltht-react/utils'
+import { partialDateTimeText, formatPartialDateTimeAsDateOnly } from '@ltht-react/utils'
 
 const StyledDateSummary = styled.div<IStyledDateSummary>`
   color: ${TEXT_COLOURS.PRIMARY};
@@ -12,16 +11,9 @@ const StyledDateSummary = styled.div<IStyledDateSummary>`
   display: inline-block;
 `
 
-const formatAsISODate = (partialDateTime?: PartialDateTime | null): string => {
-  if (!partialDateTime?.value) return ''
-
-  const date = parseISO(partialDateTime.value)
-  return format(date, 'dd-MMM-yyyy')
-}
-
 const DateSummary: FC<Props> = ({ datetime, enteredInError, dateOnlyView, ...rest }) => (
   <StyledDateSummary enteredInError={enteredInError} dateOnlyView={dateOnlyView} {...rest}>
-    {dateOnlyView ? formatAsISODate(datetime) : partialDateTimeText(datetime)}
+    {dateOnlyView ? formatPartialDateTimeAsDateOnly(datetime) : partialDateTimeText(datetime)}
   </StyledDateSummary>
 )
 

--- a/packages/utils/src/atoms/partial-date-time.test.ts
+++ b/packages/utils/src/atoms/partial-date-time.test.ts
@@ -1,5 +1,5 @@
 import { PartialDateTime, PartialDateTimeKindCode } from '@ltht-react/types'
-import { formatDateTime, partialDateTimeText } from './partial-date-time'
+import { formatDateTime, partialDateTimeText, formatPartialDateTimeAsDateOnly } from './partial-date-time'
 
 describe('partialDateTimeText', () => {
   // it('formats date correctly', () => {
@@ -36,6 +36,11 @@ describe('partialDateTimeText', () => {
   it('formats DateTimes as midnight by default if no time is provided', () => {
     const date = new Date(2022, 0, 10)
     expect(formatDateTime(date)).toEqual('10 January 2022 : 00:00')
+  })
+
+  it('formats DateTimes to show date portion only in DD-MMM-YYYY format', () => {
+    const date = partialDateTime(PartialDateTimeKindCode.DateTime)
+    expect(formatPartialDateTimeAsDateOnly(date)).toEqual('03-Feb-2013')
   })
 })
 

--- a/packages/utils/src/atoms/partial-date-time.ts
+++ b/packages/utils/src/atoms/partial-date-time.ts
@@ -1,4 +1,5 @@
 import { PartialDateTime, PartialDateTimeKindCode } from '@ltht-react/types'
+import { format, parseISO } from 'date-fns'
 
 const locale = 'en-gb'
 const dayFormat = '2-digit'
@@ -42,4 +43,11 @@ export const partialDateTimeText = (partialDateTime?: PartialDateTime | null): s
     default:
       return ''
   }
+}
+
+export const formatPartialDateTimeAsDateOnly = (partialDateTime?: PartialDateTime | null): string => {
+  if (!partialDateTime?.value) return ''
+
+  const date = parseISO(partialDateTime.value)
+  return format(date, 'dd-MMM-yyyy')
 }


### PR DESCRIPTION
- Moved formatPartialDateTimeAsDateOnly into utils folder with other format methods
- Added test for formatPartialDateTimeAsDateOnly
- Applied the same logic to the detail view so that it formats the same way the list view does