### PR TITLE
adding back onset property to support older code in uat1

### DIFF
--- a/packages/types/src/atoms/graphql-types.ts
+++ b/packages/types/src/atoms/graphql-types.ts
@@ -890,6 +890,11 @@ export type ConditionMinimalInput = {
   extension?: Maybe<Array<Maybe<ExtensionInput>>>;
   id: Scalars['String'];
   verificationStatus?: Maybe<ConditionVerificationStatus>;
+  onset?: Maybe<ConditionOnsetMinimalInput>;
+};
+
+export type ConditionOnsetMinimalInput = {
+  dateTime: PartialDateTimeInput;
 };
 
 export type ConditionMinimalInputList = {


### PR DESCRIPTION
temporary measure to stop tests and lint failing for uat1 branch with new version of ltht-react package since the onset date changes are not part of RC. there will be another PR to remove this and update to new version on UAT2 to be inline for next RC.