### PR TITLE
EHR-31618 Scope Type is not part of condition and can be a generic non fhir type

### DIFF
--- a/packages/types/src/atoms/graphql-types.ts
+++ b/packages/types/src/atoms/graphql-types.ts
@@ -908,11 +908,6 @@ export type ConditionOnset = {
   string?: Maybe<Scalars['String']>;
 };
 
-export enum ConditionScopeType {
-  Pathway = 'PATHWAY',
-  Patient = 'PATIENT'
-}
-
 export type ConditionStage = {
   assessment?: Maybe<Array<Maybe<ResourceReference>>>;
   /** Unique id for inter-element referencing. */
@@ -1516,7 +1511,7 @@ export type EhrConditionsArgs = {
   cursorToken?: Maybe<Scalars['String']>;
   loadSpec?: Maybe<InstanceDataLoadSpecType>;
   patientGuid: Scalars['String'];
-  scopeType: ConditionScopeType;
+  scopeType: ScopeType;
   search?: Maybe<Scalars['String']>;
   severity?: Maybe<Array<Maybe<Scalars['String']>>>;
   sortBy?: Maybe<SortOptionType>;
@@ -4014,6 +4009,11 @@ export type SampledData = {
   /** Upper limit of detection */
   upperLimit?: Maybe<Scalars['Decimal']>;
 };
+
+export enum ScopeType {
+  Pathway = 'PATHWAY',
+  Patient = 'PATIENT'
+}
 
 /** Users and / or teams that will be requested to sign a document */
 export type SignatoryInputType = {


### PR DESCRIPTION
Ran this by Jim and we agreed that Scope Type isn't part of the fhir condition, however is useful as more of a generic type