### PR TITLE
EHR-31273 Include Clinical and Verification status in title

### DIFF
--- a/components/clinical/diagnosis-summary/src/atoms/diagnosis-title.tsx
+++ b/components/clinical/diagnosis-summary/src/atoms/diagnosis-title.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled'
 
 import { TEXT_COLOURS } from '@ltht-react/styles'
 import { Condition } from '@ltht-react/types'
-import { codeableConceptTextSummary } from '@ltht-react/utils'
+import { codeableConceptTextSummary, titleCase } from '@ltht-react/utils'
 
 const StyledConditionTitle = styled.div<IStyledDescription>`
   color: ${TEXT_COLOURS.PRIMARY};
@@ -13,12 +13,16 @@ const StyledConditionTitle = styled.div<IStyledDescription>`
 
 const DiagnosisTitle: FC<Props> = ({ condition, enteredInError, ...rest }) => {
   const codes = []
+  const snippets = []
 
   if (condition.code) codes.push(condition.code)
+  snippets.push(codeableConceptTextSummary(codes))
+  if (condition.clinicalStatus) snippets.push(titleCase(condition.clinicalStatus))
+  if (condition.verificationStatus) snippets.push(titleCase(condition.verificationStatus))
 
   return (
     <StyledConditionTitle enteredInError={enteredInError} {...rest}>
-      {codeableConceptTextSummary(codes)}
+      {snippets.length > 0 ? snippets.join(', ') : 'Insufficient data provided'}
     </StyledConditionTitle>
   )
 }

--- a/components/clinical/diagnosis-summary/src/organisms/diagnosis-summary.tsx
+++ b/components/clinical/diagnosis-summary/src/organisms/diagnosis-summary.tsx
@@ -8,7 +8,6 @@ import { Button, ButtonProps } from '@ltht-react/button'
 
 import { BTN_COLOURS, MOBILE_MAXIMUM_MEDIA_QUERY, SMALL_SCREEN_MAXIMUM_MEDIA_QUERY } from '@ltht-react/styles'
 import Category from '../atoms/diagnosis-category'
-import Status from '../atoms/diagnosis-status'
 import Title from '../atoms/diagnosis-title'
 import OnsetDateEstimated from '../atoms/diagnosis-onset-estimated'
 import Redacted from '../molecules/diagnosis-redacted'
@@ -146,7 +145,6 @@ const DiagnosisSummary: FC<Props> = ({
       <StyledDate>
         <DateSummary enteredInError={enteredInError} datetime={condition?.assertedDate} dateOnlyView={dateOnlyView} />
         <OnsetDateEstimated enteredInError={enteredInError} condition={condition} />
-        <Status enteredInError={enteredInError} condition={condition} />
       </StyledDate>
     </StyledSummary>
   )


### PR DESCRIPTION
Following the convention that the DiagnosisStatus component used to previously display the Clinical & Verification Status, the DiagnosisTitle now does the same thing but with the addition of the Condition.
The new appearance is:
![image](https://github.com/user-attachments/assets/60fdd7d6-3343-4267-ad63-27d6990621ff)
