### PR TITLE
Add fallback ID to eform iframe

### DIFF
--- a/components/clinical/eForm/src/index.tsx
+++ b/components/clinical/eForm/src/index.tsx
@@ -21,7 +21,7 @@ const StyledIframe = styled.div`
   }
 `
 
-const EForm: FC<Props> = ({ url, callback, checksum = 0, ...rest }) => {
+const EForm: FC<Props> = ({ url, callback, checksum = 0, id, ...rest }) => {
   const [iframeKey, setIframeKey] = useState(0)
   const iframeRef = useRef<HTMLIFrameElement | null>(null)
 
@@ -61,7 +61,14 @@ const EForm: FC<Props> = ({ url, callback, checksum = 0, ...rest }) => {
 
   return (
     <StyledIframe {...rest}>
-      <iframe key={iframeKey} ref={iframeRef} src={url} title="eForm" data-iframe-key={iframeKey} />
+      <iframe
+        key={iframeKey}
+        ref={iframeRef}
+        src={url}
+        title="eForm"
+        data-iframe-key={iframeKey}
+        id={id ?? 'f4h-eform-iframe'}
+      />
     </StyledIframe>
   )
 }

--- a/packages/storybook/src/clinical/organisms/eForm/eForm.test.tsx
+++ b/packages/storybook/src/clinical/organisms/eForm/eForm.test.tsx
@@ -10,4 +10,16 @@ describe('eForm', () => {
 
     expect(initialIframeKey).toBe('1')
   })
+
+  it('should put the id on the iframe', () => {
+    render(<EForm url="https://localhost" id="test-iframe" />)
+
+    expect(screen.getByTitle('eForm')).toHaveAttribute('id', 'test-iframe')
+  })
+
+  it('should have a default iframe id', () => {
+    render(<EForm url="https://localhost" />)
+
+    expect(screen.getByTitle('eForm')).toHaveAttribute('id', 'f4h-eform-iframe')
+  })
 })


### PR DESCRIPTION
Add a fallback id to the eform iframe, also means that a passed id attribute will be applied to the iframe rather than the wrapper.

This is to aid automation testing of consumer applications.