### PR TITLE
Show Diagnosis Snippet Text on dashboard

### DIFF
--- a/components/clinical/diagnosis-detail/src/constants.ts
+++ b/components/clinical/diagnosis-detail/src/constants.ts
@@ -1,0 +1,3 @@
+const SNIPPET_TEXT = 'https://leedsth.nhs.uk/cds/snippet-text'
+
+export default SNIPPET_TEXT

--- a/components/clinical/diagnosis-detail/src/organisms/diagnosis-detail.tsx
+++ b/components/clinical/diagnosis-detail/src/organisms/diagnosis-detail.tsx
@@ -6,7 +6,6 @@ import {
   AnnotationListDetail,
   CodeableConceptDetail,
   DatetimeDetail,
-  CodingListDetail,
   CollapsibleDetailCollection,
   CollapsibleDetailCollectionProps,
   AsserterDetail,
@@ -15,6 +14,8 @@ import {
 import { getBooleanExtension } from '@ltht-react/utils'
 
 import Questionnaire from '@ltht-react/questionnaire'
+import CodingDetail from '@ltht-react/type-detail/lib/molecules/coding-detail'
+import SNIPPET_TEXT from '../constants'
 
 const TopSection = styled.div`
   display: flex;
@@ -23,7 +24,7 @@ const TopSection = styled.div`
   margin-bottom: 1rem;
 `
 
-const Seperator = styled.div`
+const Separator = styled.div`
   height: 1px;
   background: rgba(0, 0, 0, 0.125);
   width: calc(100% + 12px);
@@ -36,12 +37,14 @@ const DiagnosisDetail: FC<Props> = ({ condition, links, viewType = DetailViewTyp
     'https://fhir.leedsth.nhs.uk/ValueSet/diagnosis-onset-date-estimated-1'
   )
 
+  const snippetTextCoding = condition?.metadata.tag?.find((coding) => coding?.system === SNIPPET_TEXT) ?? null
+
   return (
     <>
       <TopSection>
-        <CodingListDetail term="Data Source(s)" codings={condition.metadata.dataSources} />
+        <CodingDetail term="Diagnosis Snippet" coding={snippetTextCoding} />
       </TopSection>
-      <Seperator />
+      <Separator />
       <CollapsibleDetailCollection viewType={viewType}>
         <CodeableConceptDetail term="Diagnosis / Condition" concept={condition.code} links={links} />
         <DatetimeDetail term="Diagnosis Date" datetime={condition.assertedDate} dateOnly={dateOnly} />
@@ -58,13 +61,13 @@ const DiagnosisDetail: FC<Props> = ({ condition, links, viewType = DetailViewTyp
         <AnnotationListDetail term="Note(s)" notes={condition.note} />
         <AsserterDetail asserter={condition.asserter} />
       </CollapsibleDetailCollection>
-      <Seperator />
+      <Separator />
 
       {condition.extensionData &&
         condition?.extensionData.map((item, index) => (
           <div key={`diagnosis-detail-questionnaire-${index}`}>
             <Questionnaire questionnaire={item} showTitle={false} viewType={viewType} />
-            <Seperator />
+            <Separator />
           </div>
         ))}
     </>

--- a/components/clinical/diagnosis-detail/src/organisms/diagnosis-detail.tsx
+++ b/components/clinical/diagnosis-detail/src/organisms/diagnosis-detail.tsx
@@ -15,7 +15,7 @@ import { getBooleanExtension } from '@ltht-react/utils'
 
 import Questionnaire from '@ltht-react/questionnaire'
 import CodingDetail from '@ltht-react/type-detail/lib/molecules/coding-detail'
-import SNIPPET_TEXT from '../constants'
+import SNIPPET_HOVER_TEXT from '../constants'
 
 const TopSection = styled.div`
   display: flex;
@@ -37,7 +37,7 @@ const DiagnosisDetail: FC<Props> = ({ condition, links, viewType = DetailViewTyp
     'https://fhir.leedsth.nhs.uk/ValueSet/diagnosis-onset-date-estimated-1'
   )
 
-  const snippetTextCoding = condition?.metadata.tag?.find((coding) => coding?.system === SNIPPET_TEXT) ?? null
+  const snippetTextCoding = condition?.metadata.tag?.find((coding) => coding?.system === SNIPPET_HOVER_TEXT) ?? null
 
   return (
     <>

--- a/components/clinical/diagnosis-summary/src/atoms/diagnosis-sub-header.tsx
+++ b/components/clinical/diagnosis-summary/src/atoms/diagnosis-sub-header.tsx
@@ -1,0 +1,29 @@
+import { FC, HTMLAttributes } from 'react'
+import styled from '@emotion/styled'
+
+import { TEXT_COLOURS } from '@ltht-react/styles'
+
+const StyledConditionSubHeader = styled.div<IStyledDescription>`
+  color: ${TEXT_COLOURS.SECONDARY.VALUE};
+  text-align: left;
+  font-size: smaller;
+  padding-top: 0.25rem;
+  text-decoration: ${({ enteredInError }) => (enteredInError ? 'line-through' : 'none')};
+`
+
+const DiagnosisSubHeader: FC<Props> = ({ text, enteredInError, ...rest }) => (
+  <StyledConditionSubHeader enteredInError={enteredInError} {...rest}>
+    {text}
+  </StyledConditionSubHeader>
+)
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+  text: string
+  enteredInError: boolean
+}
+
+interface IStyledDescription {
+  enteredInError: boolean
+}
+
+export default DiagnosisSubHeader

--- a/components/clinical/diagnosis-summary/src/atoms/diagnosis-title.tsx
+++ b/components/clinical/diagnosis-summary/src/atoms/diagnosis-title.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled'
 
 import { TEXT_COLOURS } from '@ltht-react/styles'
 import { Condition } from '@ltht-react/types'
-import { codeableConceptTextSummary, titleCase } from '@ltht-react/utils'
+import { codeableConceptTextSummary } from '@ltht-react/utils'
 
 const StyledConditionTitle = styled.div<IStyledDescription>`
   color: ${TEXT_COLOURS.PRIMARY};
@@ -17,8 +17,6 @@ const DiagnosisTitle: FC<Props> = ({ condition, enteredInError, ...rest }) => {
 
   if (condition.code) codes.push(condition.code)
   snippets.push(codeableConceptTextSummary(codes))
-  if (condition.clinicalStatus) snippets.push(titleCase(condition.clinicalStatus))
-  if (condition.verificationStatus) snippets.push(titleCase(condition.verificationStatus))
 
   return (
     <StyledConditionTitle enteredInError={enteredInError} {...rest}>

--- a/components/clinical/diagnosis-summary/src/constants.ts
+++ b/components/clinical/diagnosis-summary/src/constants.ts
@@ -1,0 +1,3 @@
+const SNIPPET_TEXT = 'https://leedsth.nhs.uk/cds/snippet-text'
+
+export default SNIPPET_TEXT

--- a/components/clinical/diagnosis-summary/src/organisms/diagnosis-summary.tsx
+++ b/components/clinical/diagnosis-summary/src/organisms/diagnosis-summary.tsx
@@ -79,9 +79,7 @@ const IconButtonWrapper = styled(Button)`
   width: auto;
 `
 const IconWrapper = styled.div`
-  align-items: start;
-  justify-content: center;
-  margin: 0.5rem;
+  margin-left: 0.5rem;
   display: inline-block;
 `
 

--- a/components/clinical/diagnosis-summary/src/organisms/diagnosis-summary.tsx
+++ b/components/clinical/diagnosis-summary/src/organisms/diagnosis-summary.tsx
@@ -112,7 +112,6 @@ const DiagnosisSummary: FC<Props> = ({
         <StyledDescription>
           <StyledTitle>
             <Title enteredInError={enteredInError} condition={condition} />
-            <SubHeader enteredInError={enteredInError} text={snippetText} />
           </StyledTitle>
           {extensionTemplateDisplayName && !isReadOnly && canExtendDiagnosis && !enteredInError && (
             <IconButtonWrapper
@@ -136,6 +135,7 @@ const DiagnosisSummary: FC<Props> = ({
               />
             </IconWrapper>
           )}
+          <SubHeader enteredInError={enteredInError} text={snippetText} />
         </StyledDescription>
 
         {!isReadOnly && controls.length > 0 && (

--- a/components/clinical/diagnosis-summary/src/organisms/diagnosis-summary.tsx
+++ b/components/clinical/diagnosis-summary/src/organisms/diagnosis-summary.tsx
@@ -7,10 +7,11 @@ import Icon from '@ltht-react/icon'
 import { Button, ButtonProps } from '@ltht-react/button'
 
 import { BTN_COLOURS, MOBILE_MAXIMUM_MEDIA_QUERY, SMALL_SCREEN_MAXIMUM_MEDIA_QUERY } from '@ltht-react/styles'
-import Category from '../atoms/diagnosis-category'
 import Title from '../atoms/diagnosis-title'
+import SubHeader from '../atoms/diagnosis-sub-header'
 import OnsetDateEstimated from '../atoms/diagnosis-onset-estimated'
 import Redacted from '../molecules/diagnosis-redacted'
+import SNIPPET_TEXT from '../constants'
 
 const StyledTitle = styled.div`
   display: inline-block;
@@ -78,7 +79,9 @@ const IconButtonWrapper = styled(Button)`
   width: auto;
 `
 const IconWrapper = styled.div`
-  margin-left: 0.5rem;
+  align-items: start;
+  justify-content: center;
+  margin: 0.5rem;
   display: inline-block;
 `
 
@@ -103,12 +106,15 @@ const DiagnosisSummary: FC<Props> = ({
 
   const enteredInError = condition.verificationStatus === ConditionVerificationStatus.EnteredInError
 
+  const snippetText = condition?.metadata.tag?.find((coding) => coding?.system === SNIPPET_TEXT)?.display ?? ''
+
   return (
     <StyledSummary {...rest}>
       <StyledLeftContainer>
         <StyledDescription>
           <StyledTitle>
             <Title enteredInError={enteredInError} condition={condition} />
+            <SubHeader enteredInError={enteredInError} text={snippetText} />
           </StyledTitle>
           {extensionTemplateDisplayName && !isReadOnly && canExtendDiagnosis && !enteredInError && (
             <IconButtonWrapper
@@ -132,7 +138,6 @@ const DiagnosisSummary: FC<Props> = ({
               />
             </IconWrapper>
           )}
-          <Category enteredInError={enteredInError} condition={condition} />
         </StyledDescription>
 
         {!isReadOnly && controls.length > 0 && (

--- a/components/clinical/diagnosis-summary/src/organisms/diagnosis-summary.tsx
+++ b/components/clinical/diagnosis-summary/src/organisms/diagnosis-summary.tsx
@@ -11,7 +11,7 @@ import Title from '../atoms/diagnosis-title'
 import SubHeader from '../atoms/diagnosis-sub-header'
 import OnsetDateEstimated from '../atoms/diagnosis-onset-estimated'
 import Redacted from '../molecules/diagnosis-redacted'
-import SNIPPET_TEXT from '../constants'
+import SNIPPET_HOVER_TEXT from '../constants'
 
 const StyledTitle = styled.div`
   display: inline-block;
@@ -104,7 +104,7 @@ const DiagnosisSummary: FC<Props> = ({
 
   const enteredInError = condition.verificationStatus === ConditionVerificationStatus.EnteredInError
 
-  const snippetText = condition?.metadata.tag?.find((coding) => coding?.system === SNIPPET_TEXT)?.display ?? ''
+  const snippetText = condition?.metadata.tag?.find((coding) => coding?.system === SNIPPET_HOVER_TEXT)?.display ?? ''
 
   return (
     <StyledSummary {...rest}>

--- a/components/clinical/shared/type-detail/src/molecules/coding-detail.tsx
+++ b/components/clinical/shared/type-detail/src/molecules/coding-detail.tsx
@@ -1,0 +1,17 @@
+import DescriptionList from '@ltht-react/description-list'
+import { Coding, Maybe } from '@ltht-react/types'
+import { DetailViewComponent, IDetailViewProps } from '../atoms/detail-view-component'
+import NestedListDetail from './nested-list-detail'
+
+const CodingDetail: DetailViewComponent<IProps> = ({ term, coding, showIfEmpty = false }) => (
+  <NestedListDetail term={term} showIfEmpty={showIfEmpty} wrapDescription={false}>
+    {coding?.display ? <DescriptionList.Description key={term}>{coding.display}</DescriptionList.Description> : <></>}
+  </NestedListDetail>
+)
+
+interface IProps extends IDetailViewProps {
+  term: string
+  coding?: Maybe<Coding>
+}
+
+export default CodingDetail

--- a/packages/storybook/src/clinical/atoms/diagnosis/diagnosis-title.test.tsx
+++ b/packages/storybook/src/clinical/atoms/diagnosis/diagnosis-title.test.tsx
@@ -11,14 +11,12 @@ describe('Diagnosis Title', () => {
   it('Renders clinical code text summaries', () => {
     render(<DiagnosisTitle condition={conditionWithClinicalCode} enteredInError={false} />)
 
-    expect(screen.getByText('This is a clinical coding text summary, Active, Confirmed')).toBeVisible()
+    expect(screen.getByText('This is a clinical coding text summary')).toBeVisible()
   })
 
   it('Adds the strikethrough property to code summaries if entered in error', () => {
     render(<DiagnosisTitle condition={conditionWithClinicalCode} enteredInError />)
 
-    expect(screen.getByText('This is a clinical coding text summary, Active, Confirmed')).toHaveStyle(
-      'text-decoration: line-through'
-    )
+    expect(screen.getByText('This is a clinical coding text summary')).toHaveStyle('text-decoration: line-through')
   })
 })

--- a/packages/storybook/src/clinical/organisms/diagnosis/diagnosis-detail.test.tsx
+++ b/packages/storybook/src/clinical/organisms/diagnosis/diagnosis-detail.test.tsx
@@ -32,8 +32,8 @@ describe('Diagnosis Detail', () => {
     expect(screen.getByText('Diagnosis / Condition')).toBeVisible()
     expect(screen.getByText('Heel Pain')).toBeVisible()
 
-    expect(screen.getByText('Data Source(s)')).toBeVisible()
-    expect(screen.getByText('Mock')).toBeVisible()
+    expect(screen.getByText('Diagnosis Snippet')).toBeVisible()
+    expect(screen.getByText('Mock snippet text value')).toBeVisible()
 
     expect(screen.getByText('Onset Date (Symptoms)')).toBeVisible()
     expect(screen.getByText('Sept-2016')).toBeVisible()

--- a/packages/storybook/src/clinical/organisms/diagnosis/diagnosis-detail.test.tsx
+++ b/packages/storybook/src/clinical/organisms/diagnosis/diagnosis-detail.test.tsx
@@ -33,7 +33,7 @@ describe('Diagnosis Detail', () => {
     expect(screen.getByText('Heel Pain')).toBeVisible()
 
     expect(screen.getByText('Diagnosis Snippet')).toBeVisible()
-    expect(screen.getByText('Mock snippet text value')).toBeVisible()
+    expect(screen.getByText('Mock snippet hover text value')).toBeVisible()
 
     expect(screen.getByText('Onset Date (Symptoms)')).toBeVisible()
     expect(screen.getByText('Sept-2016')).toBeVisible()

--- a/packages/storybook/src/clinical/organisms/diagnosis/diagnosis.fixtures.tsx
+++ b/packages/storybook/src/clinical/organisms/diagnosis/diagnosis.fixtures.tsx
@@ -18,6 +18,12 @@ const mockMetadata: Metadata = {
       display: 'Mock',
     },
   ],
+  tag: [
+    {
+      system: 'https://leedsth.nhs.uk/cds/snippet-text',
+      display: 'Mock snippet text value',
+    },
+  ],
   isRedacted: false,
   requestedWhen: '',
 }
@@ -525,6 +531,10 @@ const ConditionOne: Condition = {
       {
         system: 'https://leedsth.nhs.uk/cds/extension-template-version',
         display: '1',
+      },
+      {
+        system: 'https://leedsth.nhs.uk/cds/snippet-text',
+        display: 'Mock snippet text value',
       },
     ],
   },

--- a/packages/storybook/src/clinical/organisms/diagnosis/diagnosis.fixtures.tsx
+++ b/packages/storybook/src/clinical/organisms/diagnosis/diagnosis.fixtures.tsx
@@ -23,6 +23,10 @@ const mockMetadata: Metadata = {
       system: 'https://leedsth.nhs.uk/cds/snippet-text',
       display: 'Mock snippet text value',
     },
+    {
+      system: 'https://leedsth.nhs.uk/cds/snippet-hover-text',
+      display: 'Mock snippet hover text value',
+    },
   ],
   isRedacted: false,
   requestedWhen: '',
@@ -535,6 +539,10 @@ const ConditionOne: Condition = {
       {
         system: 'https://leedsth.nhs.uk/cds/snippet-text',
         display: 'Mock snippet text value',
+      },
+      {
+        system: 'https://leedsth.nhs.uk/cds/snippet-hover-text',
+        display: 'Mock snippet hover text value',
       },
     ],
   },

--- a/packages/storybook/src/clinical/organisms/diagnosis/diagnosis.test.tsx
+++ b/packages/storybook/src/clinical/organisms/diagnosis/diagnosis.test.tsx
@@ -8,7 +8,7 @@ describe('Diagnosis', () => {
   it('Renders', () => {
     render(<DiagnosisSummary condition={{ ...conditions[0] }} isReadOnly={false} />)
 
-    expect(screen.getByText('Heel Pain, Active, Confirmed')).toBeVisible()
+    expect(screen.getByText('Heel Pain')).toBeVisible()
   })
 
   it('Does not diplay redacted data', () => {
@@ -38,7 +38,7 @@ describe('Diagnosis', () => {
 
     render(<DiagnosisSummary condition={enteredInErrorCondition} isReadOnly={false} />)
 
-    expect(screen.getByText('Heel Pain, Active, Entered In Error')).toHaveStyle('text-decoration: line-through')
+    expect(screen.getByText('Heel Pain')).toHaveStyle('text-decoration: line-through')
   })
 
   it('Displays a button for extending the diagnosis if a template name is provided and readonly is false', () => {


### PR DESCRIPTION
- Replace 'Data Source(s)' field on Diagnosis Detail view with the snippet text 
![image](https://github.com/user-attachments/assets/b1c5ae0a-b174-4e6f-875c-fd6021c0d645)


- Remove Diagnosis Category component (the part that shows Severity as a subheader) in the Diagnosis List view
- Remove Verification Status and Clinical Status from being appended to the condition as part of the title
- Add snippet text as subheader in list view
![image](https://github.com/user-attachments/assets/4ff60600-7ce6-4d22-b31a-e4244bf7aac2)

