### PR TITLE
Allow filtering by codingSystem for Diagnosis Summary

### DIFF
--- a/components/clinical/diagnosis-detail/src/organisms/diagnosis-detail.tsx
+++ b/components/clinical/diagnosis-detail/src/organisms/diagnosis-detail.tsx
@@ -31,7 +31,13 @@ const Separator = styled.div`
   margin: 1rem 0;
 `
 
-const DiagnosisDetail: FC<Props> = ({ condition, links, viewType = DetailViewType.Compact, dateOnly = false }) => {
+const DiagnosisDetail: FC<Props> = ({
+  condition,
+  links,
+  viewType = DetailViewType.Compact,
+  dateOnly = false,
+  systemExclusionsFilter = [],
+}) => {
   const onsetDateEstimated = getBooleanExtension(
     condition.extension,
     'https://fhir.leedsth.nhs.uk/ValueSet/diagnosis-onset-date-estimated-1'
@@ -56,7 +62,12 @@ const DiagnosisDetail: FC<Props> = ({ condition, links, viewType = DetailViewTyp
         </>
       )}
       <CollapsibleDetailCollection viewType={viewType}>
-        <CodeableConceptDetail term="Diagnosis / Condition" concept={condition.code} links={links} />
+        <CodeableConceptDetail
+          term="Diagnosis / Condition"
+          concept={condition.code}
+          links={links}
+          systemExclusionsFilter={systemExclusionsFilter}
+        />
         <DatetimeDetail term="Diagnosis Date" datetime={condition.assertedDate} dateOnly={dateOnly} />
         <DatetimeDetail
           term="Onset Date (Symptoms)"
@@ -90,6 +101,7 @@ interface Props extends CollapsibleDetailCollectionProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   links?: any
   dateOnly?: boolean
+  systemExclusionsFilter?: string[]
 }
 
 export default DiagnosisDetail

--- a/components/clinical/diagnosis-summary/src/atoms/diagnosis-title.tsx
+++ b/components/clinical/diagnosis-summary/src/atoms/diagnosis-title.tsx
@@ -12,26 +12,26 @@ const StyledConditionTitle = styled.div<IStyledDescription>`
   text-decoration: ${({ enteredInError }) => (enteredInError ? 'line-through' : 'none')};
 `
 
-const DiagnosisTitle: FC<Props> = ({ condition, enteredInError, codingSystemFilter }) => {
+const DiagnosisTitle: FC<Props> = ({ condition, enteredInError, systemExclusionsFilter }) => {
   const snippetTagText = extractSnippetTagDisplayValue(condition)
 
   if (snippetTagText) {
     return renderTitle(snippetTagText, enteredInError)
   }
 
-  const conditionText = extractConditionOrFallbackText(condition, codingSystemFilter)
+  const conditionText = extractConditionOrFallbackText(condition, systemExclusionsFilter)
   const conditionStatusText = extractConditionStatusText(condition)
   const title = conditionStatusText ? `${conditionText}, ${conditionStatusText}` : conditionText
 
   return renderTitle(title, enteredInError)
 }
 
-const extractConditionOrFallbackText = (condition: Condition, codingSystemFilter?: string): string => {
+const extractConditionOrFallbackText = (condition: Condition, systemExclusionsFilter?: string[]): string => {
   if (!condition?.code) {
     return titleCase('Unknown Condition')
   }
 
-  const diagnosisTitle = codeableConceptDisplaySummary(condition.code, codingSystemFilter)
+  const diagnosisTitle = codeableConceptDisplaySummary(condition.code, systemExclusionsFilter)
 
   return titleCase(diagnosisTitle || 'Unknown Condition')
 }
@@ -60,7 +60,7 @@ const renderTitle = (title: string, enteredInError: boolean) => (
 interface Props extends HTMLAttributes<HTMLDivElement> {
   condition: Condition
   enteredInError: boolean
-  codingSystemFilter?: string
+  systemExclusionsFilter?: string[]
 }
 
 interface IStyledDescription {

--- a/components/clinical/diagnosis-summary/src/atoms/diagnosis-title.tsx
+++ b/components/clinical/diagnosis-summary/src/atoms/diagnosis-title.tsx
@@ -12,26 +12,26 @@ const StyledConditionTitle = styled.div<IStyledDescription>`
   text-decoration: ${({ enteredInError }) => (enteredInError ? 'line-through' : 'none')};
 `
 
-const DiagnosisTitle: FC<Props> = ({ condition, enteredInError, codingSystem }) => {
+const DiagnosisTitle: FC<Props> = ({ condition, enteredInError, codingSystemFilter }) => {
   const snippetTagText = extractSnippetTagDisplayValue(condition)
 
   if (snippetTagText) {
     return renderTitle(snippetTagText, enteredInError)
   }
 
-  const conditionText = extractConditionOrFallbackText(condition, codingSystem)
+  const conditionText = extractConditionOrFallbackText(condition, codingSystemFilter)
   const conditionStatusText = extractConditionStatusText(condition)
   const title = conditionStatusText ? `${conditionText}, ${conditionStatusText}` : conditionText
 
   return renderTitle(title, enteredInError)
 }
 
-const extractConditionOrFallbackText = (condition: Condition, codingSystem?: string): string => {
+const extractConditionOrFallbackText = (condition: Condition, codingSystemFilter?: string): string => {
   if (!condition?.code) {
     return titleCase('Unknown Condition')
   }
 
-  const diagnosisTitle = codeableConceptDisplaySummary(condition.code, codingSystem)
+  const diagnosisTitle = codeableConceptDisplaySummary(condition.code, codingSystemFilter)
 
   return titleCase(diagnosisTitle || 'Unknown Condition')
 }
@@ -60,7 +60,7 @@ const renderTitle = (title: string, enteredInError: boolean) => (
 interface Props extends HTMLAttributes<HTMLDivElement> {
   condition: Condition
   enteredInError: boolean
-  codingSystem?: string
+  codingSystemFilter?: string
 }
 
 interface IStyledDescription {

--- a/components/clinical/diagnosis-summary/src/atoms/diagnosis-title.tsx
+++ b/components/clinical/diagnosis-summary/src/atoms/diagnosis-title.tsx
@@ -12,26 +12,26 @@ const StyledConditionTitle = styled.div<IStyledDescription>`
   text-decoration: ${({ enteredInError }) => (enteredInError ? 'line-through' : 'none')};
 `
 
-const DiagnosisTitle: FC<Props> = ({ condition, enteredInError }) => {
+const DiagnosisTitle: FC<Props> = ({ condition, enteredInError, codingSystem }) => {
   const snippetTagText = extractSnippetTagDisplayValue(condition)
 
   if (snippetTagText) {
     return renderTitle(snippetTagText, enteredInError)
   }
 
-  const conditionText = extractConditionOrFallbackText(condition)
+  const conditionText = extractConditionOrFallbackText(condition, codingSystem)
   const conditionStatusText = extractConditionStatusText(condition)
   const title = conditionStatusText ? `${conditionText}, ${conditionStatusText}` : conditionText
 
   return renderTitle(title, enteredInError)
 }
 
-const extractConditionOrFallbackText = (condition: Condition): string => {
+const extractConditionOrFallbackText = (condition: Condition, codingSystem?: string): string => {
   if (!condition?.code) {
     return titleCase('Unknown Condition')
   }
 
-  const diagnosisTitle = codeableConceptDisplaySummary(condition.code)
+  const diagnosisTitle = codeableConceptDisplaySummary(condition.code, codingSystem)
 
   return titleCase(diagnosisTitle || 'Unknown Condition')
 }
@@ -60,6 +60,7 @@ const renderTitle = (title: string, enteredInError: boolean) => (
 interface Props extends HTMLAttributes<HTMLDivElement> {
   condition: Condition
   enteredInError: boolean
+  codingSystem?: string
 }
 
 interface IStyledDescription {

--- a/components/clinical/diagnosis-summary/src/organisms/diagnosis-summary.tsx
+++ b/components/clinical/diagnosis-summary/src/organisms/diagnosis-summary.tsx
@@ -105,6 +105,7 @@ const DiagnosisSummary: FC<Props> = ({
   displaySource = false,
   controls = [],
   tags = [],
+  codingSystem = '',
   ...rest
 }) => {
   if (condition.metadata.isRedacted) {
@@ -122,7 +123,7 @@ const DiagnosisSummary: FC<Props> = ({
       <StyledLeftContainer>
         <StyledDescription>
           <StyledTitle>
-            <Title enteredInError={enteredInError} condition={condition} />
+            <Title enteredInError={enteredInError} condition={condition} codingSystem={codingSystem} />
           </StyledTitle>
           {extensionTemplateDisplayName && !isReadOnly && canExtendDiagnosis && !enteredInError && (
             <IconButtonWrapper
@@ -182,8 +183,8 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
   controls?: ButtonProps[]
   tags?: ReactElement[]
   canExtendDiagnosis?: boolean
-
   extensionClickHandler?(): void
+  codingSystem?: string
 }
 
 export default DiagnosisSummary

--- a/components/clinical/diagnosis-summary/src/organisms/diagnosis-summary.tsx
+++ b/components/clinical/diagnosis-summary/src/organisms/diagnosis-summary.tsx
@@ -105,7 +105,7 @@ const DiagnosisSummary: FC<Props> = ({
   displaySource = false,
   controls = [],
   tags = [],
-  codingSystem = '',
+  codingSystemFilter = '',
   ...rest
 }) => {
   if (condition.metadata.isRedacted) {
@@ -123,7 +123,7 @@ const DiagnosisSummary: FC<Props> = ({
       <StyledLeftContainer>
         <StyledDescription>
           <StyledTitle>
-            <Title enteredInError={enteredInError} condition={condition} codingSystem={codingSystem} />
+            <Title enteredInError={enteredInError} condition={condition} codingSystemFilter={codingSystemFilter} />
           </StyledTitle>
           {extensionTemplateDisplayName && !isReadOnly && canExtendDiagnosis && !enteredInError && (
             <IconButtonWrapper
@@ -184,7 +184,7 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
   tags?: ReactElement[]
   canExtendDiagnosis?: boolean
   extensionClickHandler?(): void
-  codingSystem?: string
+  codingSystemFilter?: string
 }
 
 export default DiagnosisSummary

--- a/components/clinical/diagnosis-summary/src/organisms/diagnosis-summary.tsx
+++ b/components/clinical/diagnosis-summary/src/organisms/diagnosis-summary.tsx
@@ -105,7 +105,7 @@ const DiagnosisSummary: FC<Props> = ({
   displaySource = false,
   controls = [],
   tags = [],
-  codingSystemFilter = '',
+  systemExclusionsFilter = [],
   ...rest
 }) => {
   if (condition.metadata.isRedacted) {
@@ -123,7 +123,11 @@ const DiagnosisSummary: FC<Props> = ({
       <StyledLeftContainer>
         <StyledDescription>
           <StyledTitle>
-            <Title enteredInError={enteredInError} condition={condition} codingSystemFilter={codingSystemFilter} />
+            <Title
+              enteredInError={enteredInError}
+              condition={condition}
+              systemExclusionsFilter={systemExclusionsFilter}
+            />
           </StyledTitle>
           {extensionTemplateDisplayName && !isReadOnly && canExtendDiagnosis && !enteredInError && (
             <IconButtonWrapper
@@ -184,7 +188,7 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
   tags?: ReactElement[]
   canExtendDiagnosis?: boolean
   extensionClickHandler?(): void
-  codingSystemFilter?: string
+  systemExclusionsFilter?: string[]
 }
 
 export default DiagnosisSummary

--- a/components/clinical/shared/type-detail/src/molecules/codeable-concept-detail.tsx
+++ b/components/clinical/shared/type-detail/src/molecules/codeable-concept-detail.tsx
@@ -28,9 +28,15 @@ const StyledLink = styled.a`
   }
 `
 
-const CodeableConceptDetail: DetailViewComponent<IProps> = ({ term, concept, links = {}, showIfEmpty = false }) => {
+const CodeableConceptDetail: DetailViewComponent<IProps> = ({
+  term,
+  concept,
+  links = {},
+  showIfEmpty = false,
+  systemExclusionsFilter = [],
+}) => {
   if (concept || showIfEmpty === true) {
-    const displaySummary = codeableConceptDisplaySummary(concept)
+    const displaySummary = codeableConceptDisplaySummary(concept, systemExclusionsFilter)
     const linkUrl = links[displaySummary]
 
     return (
@@ -55,6 +61,7 @@ interface IProps extends IDetailViewProps {
   // TODO: Define 'links?' type once code link config implementation has been done
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   links?: any
+  systemExclusionsFilter?: string[]
 }
 
 export default CodeableConceptDetail

--- a/packages/storybook/src/clinical/molecules/detail/codeable-concept-detail.test.tsx
+++ b/packages/storybook/src/clinical/molecules/detail/codeable-concept-detail.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 
 import { CodeableConceptDetail } from '@ltht-react/type-detail'
+import { CodeableConcept } from '@ltht-react/types'
 
 import { codeableConcept } from './detail.fixtures'
 
@@ -22,6 +23,28 @@ describe('CodeableConceptDetail', () => {
     render(<CodeableConceptDetail term="Some concepts" showIfEmpty />)
 
     await screen.findByText('Some concepts')
+  })
+
+  it('filters out coding with have a system that is listed in the systemExclusionsFilter', async () => {
+    const systemExclusionsFilter = ['https://exclusion-system.test']
+
+    const testCodeableConcept: CodeableConcept = {
+      coding: [
+        { display: 'Code with no system', system: undefined },
+        { display: 'Code with regular system', system: 'http://snomed.info/sct' },
+        { display: 'Code with exclusion system', system: 'https://exclusion-system.test' },
+      ],
+    }
+
+    render(
+      <CodeableConceptDetail
+        term="Some concepts"
+        concept={testCodeableConcept}
+        systemExclusionsFilter={systemExclusionsFilter}
+      />
+    )
+
+    expect(screen.getByText('Code with no system, Code with regular system')).toBeVisible()
   })
   // TODO: Tests for external links
 })

--- a/packages/storybook/src/clinical/organisms/diagnosis/diagnosis-summary.test.tsx
+++ b/packages/storybook/src/clinical/organisms/diagnosis/diagnosis-summary.test.tsx
@@ -54,4 +54,29 @@ describe('Diagnosis Summary', () => {
       expect(screen.queryByText('Source: Humber Teaching NHS Foundation Trust')).toBeNull()
     })
   })
+
+  describe('Allow filtering by coding system for conditions displayed in summary', () => {
+    it('Renders only the text for the condition code with a system matching the provided coding system', () => {
+      const condition = conditions[2]
+      render(
+        <DiagnosisSummary
+          condition={condition}
+          displaySource={false}
+          isReadOnly
+          codingSystem="http://snomed.info/sct"
+        />
+      )
+
+      expect(screen.getByText('Cerebrovascular Disease, Active, Entered In Error')).toBeVisible()
+    })
+
+    it('Renders all condition code texts when no coding system is specified', () => {
+      const condition = conditions[2]
+      render(<DiagnosisSummary condition={condition} displaySource={false} isReadOnly />)
+
+      expect(
+        screen.getByText('Transient Ischemic Attack, Cerebrovascular Disease, Active, Entered In Error')
+      ).toBeVisible()
+    })
+  })
 })

--- a/packages/storybook/src/clinical/organisms/diagnosis/diagnosis-summary.test.tsx
+++ b/packages/storybook/src/clinical/organisms/diagnosis/diagnosis-summary.test.tsx
@@ -63,7 +63,7 @@ describe('Diagnosis Summary', () => {
           condition={condition}
           displaySource={false}
           isReadOnly
-          codingSystem="http://snomed.info/sct"
+          codingSystemFilter="http://snomed.info/sct"
         />
       )
 

--- a/packages/storybook/src/clinical/organisms/diagnosis/diagnosis-summary.test.tsx
+++ b/packages/storybook/src/clinical/organisms/diagnosis/diagnosis-summary.test.tsx
@@ -57,14 +57,7 @@ describe('Diagnosis Summary', () => {
 
   describe('Allow filtering by coding system for conditions displayed in summary', () => {
     it('Filters out condition codes from the Diagnosis Summary text that match a given coding system to filter', () => {
-      const condition = conditions[2]
-      condition.code = {
-        coding: [
-          { code: '3135009', display: 'Transient ischemic attack', system: 'http://snomed.info/sct' },
-          { code: '62914000', display: 'Cerebrovascular disease', system: 'http://alternate-snomed-code' },
-        ],
-        text: 'Transient ischemic attack',
-      }
+      const condition = conditionWithMultipleConditionCodesAndNoSnippets()
 
       const codingSystemExclusions = ['http://alternate-snomed-code']
 
@@ -89,4 +82,19 @@ describe('Diagnosis Summary', () => {
       ).toBeVisible()
     })
   })
+
+  const conditionWithMultipleConditionCodesAndNoSnippets = () => {
+    const condition = conditions[2]
+    condition.code = {
+      coding: [
+        { code: '3135009', display: 'Transient ischemic attack', system: 'http://snomed.info/sct' },
+        { code: '62914000', display: 'Cerebrovascular disease', system: 'http://alternate-snomed-code' },
+      ],
+      text: 'Transient ischemic attack',
+    }
+
+    condition.metadata.tag = []
+
+    return condition
+  }
 })

--- a/packages/storybook/src/clinical/organisms/diagnosis/diagnosis-summary.test.tsx
+++ b/packages/storybook/src/clinical/organisms/diagnosis/diagnosis-summary.test.tsx
@@ -56,21 +56,31 @@ describe('Diagnosis Summary', () => {
   })
 
   describe('Allow filtering by coding system for conditions displayed in summary', () => {
-    it('Renders only the text for the condition code with a system matching the provided coding system', () => {
+    it('Filters out condition codes from the Diagnosis Summary text that match a given coding system to filter', () => {
       const condition = conditions[2]
+      condition.code = {
+        coding: [
+          { code: '3135009', display: 'Transient ischemic attack', system: 'http://snomed.info/sct' },
+          { code: '62914000', display: 'Cerebrovascular disease', system: 'http://alternate-snomed-code' },
+        ],
+        text: 'Transient ischemic attack',
+      }
+
+      const codingSystemExclusions = ['http://alternate-snomed-code']
+
       render(
         <DiagnosisSummary
           condition={condition}
           displaySource={false}
           isReadOnly
-          codingSystemFilter="http://snomed.info/sct"
+          systemExclusionsFilter={codingSystemExclusions}
         />
       )
 
-      expect(screen.getByText('Cerebrovascular Disease, Active, Entered In Error')).toBeVisible()
+      expect(screen.getByText('Transient Ischemic Attack, Active, Entered In Error')).toBeVisible()
     })
 
-    it('Renders all condition code texts when no coding system is specified', () => {
+    it('Renders all condition code texts when no coding system filter is specified', () => {
       const condition = conditions[2]
       render(<DiagnosisSummary condition={condition} displaySource={false} isReadOnly />)
 

--- a/packages/storybook/src/clinical/organisms/diagnosis/diagnosis.fixtures.tsx
+++ b/packages/storybook/src/clinical/organisms/diagnosis/diagnosis.fixtures.tsx
@@ -843,16 +843,7 @@ const ConditionFive: Condition = {
         display: 'Mock',
       },
     ],
-    tag: [
-      {
-        system: 'https://leedsth.nhs.uk/cds/snippet-text',
-        display: 'Entered In Error, Transient ischemic attack: Active',
-      },
-      {
-        system: 'https://leedsth.nhs.uk/cds/snippet-hover-text',
-        display: 'Entered In Error, Transient ischemic attack: Active',
-      },
-    ],
+    tag: [],
     isRedacted: false,
     requestedWhen: '',
   },
@@ -875,7 +866,13 @@ const ConditionFive: Condition = {
   bodySite: [],
   category: [],
   clinicalStatus: ConditionClinicalStatus.Active,
-  code: { coding: [{ code: '3135009', display: 'Transient ischemic attack' }], text: 'Transient ischemic attack' },
+  code: {
+    coding: [
+      { code: '3135009', display: 'Transient ischemic attack' },
+      { code: '62914000', display: 'Cerebrovascular disease', system: 'http://snomed.info/sct' },
+    ],
+    text: 'Transient ischemic attack',
+  },
   evidence: [],
   extensionData: null,
   id: 'R3|cce08927-b95b-4d16-89e7-f92bd7853058',

--- a/packages/storybook/src/clinical/organisms/diagnosis/diagnosis.fixtures.tsx
+++ b/packages/storybook/src/clinical/organisms/diagnosis/diagnosis.fixtures.tsx
@@ -843,7 +843,16 @@ const ConditionFive: Condition = {
         display: 'Mock',
       },
     ],
-    tag: [],
+    tag: [
+      {
+        system: 'https://leedsth.nhs.uk/cds/snippet-text',
+        display: 'Entered In Error, Transient ischemic attack: Active',
+      },
+      {
+        system: 'https://leedsth.nhs.uk/cds/snippet-hover-text',
+        display: 'Entered In Error, Transient ischemic attack: Active',
+      },
+    ],
     isRedacted: false,
     requestedWhen: '',
   },

--- a/packages/storybook/src/clinical/organisms/diagnosis/diagnosis.fixtures.tsx
+++ b/packages/storybook/src/clinical/organisms/diagnosis/diagnosis.fixtures.tsx
@@ -866,13 +866,7 @@ const ConditionFive: Condition = {
   bodySite: [],
   category: [],
   clinicalStatus: ConditionClinicalStatus.Active,
-  code: {
-    coding: [
-      { code: '3135009', display: 'Transient ischemic attack' },
-      { code: '62914000', display: 'Cerebrovascular disease', system: 'http://snomed.info/sct' },
-    ],
-    text: 'Transient ischemic attack',
-  },
+  code: { coding: [{ code: '3135009', display: 'Transient ischemic attack' }], text: 'Transient ischemic attack' },
   evidence: [],
   extensionData: null,
   id: 'R3|cce08927-b95b-4d16-89e7-f92bd7853058',

--- a/packages/utils/src/atoms/codeable-concept.test.ts
+++ b/packages/utils/src/atoms/codeable-concept.test.ts
@@ -37,9 +37,12 @@ describe('CodeableConceptText', () => {
     })
     it('only displays codings that match the coding system if one is provided', () => {
       const codeable: CodeableConcept = {
-        coding: [{ display: 'Test', system: 'http://coding.system' }, { display: 'Another' }],
+        coding: [
+          { display: 'Test', system: 'http://coding-system-filter' },
+          { display: 'Another', system: undefined },
+        ],
       }
-      expect(codeableConceptDisplaySummary(codeable, 'http://coding.system')).toEqual('Test')
+      expect(codeableConceptDisplaySummary(codeable, ['http://coding-system-filter'])).toEqual('Another')
     })
   })
 

--- a/packages/utils/src/atoms/codeable-concept.test.ts
+++ b/packages/utils/src/atoms/codeable-concept.test.ts
@@ -35,6 +35,12 @@ describe('CodeableConceptText', () => {
       }
       expect(codeableConceptDisplaySummary(codeable)).toEqual('Test, Another')
     })
+    it('only displays codings that match the coding system if one is provided', () => {
+      const codeable: CodeableConcept = {
+        coding: [{ display: 'Test', system: 'http://coding.system' }, { display: 'Another' }],
+      }
+      expect(codeableConceptDisplaySummary(codeable, 'http://coding.system')).toEqual('Test')
+    })
   })
 
   describe('codeableConceptCodeSummary', () => {

--- a/packages/utils/src/atoms/codeable-concept.ts
+++ b/packages/utils/src/atoms/codeable-concept.ts
@@ -2,7 +2,7 @@ import { CodeableConcept, Maybe } from '@ltht-react/types'
 
 const codeableConceptDisplaySummary = (
   codeableConcept: Maybe<CodeableConcept> = {},
-  codingSystemFilter?: string
+  systemExclusionsFilter?: string[]
 ): string => {
   const codings = codeableConcept?.coding || []
 
@@ -10,9 +10,12 @@ const codeableConceptDisplaySummary = (
   // An empty array, or array of codings that don't have the display property set will return empty string
   let display = codings.map((coding) => coding?.display).join(', ')
 
-  if (codingSystemFilter) {
-    const filteredCodings = codings.filter((coding) => coding?.system === codingSystemFilter)
-    display = filteredCodings.map((coding) => coding?.display).join(', ')
+  if (systemExclusionsFilter && systemExclusionsFilter.length > 0) {
+    const filteredCodings = codings.filter(
+      (coding) => !coding?.system || !systemExclusionsFilter.includes(coding.system)
+    )
+
+    display = filteredCodings.map((coding) => coding?.display ?? '').join(', ')
   }
 
   // Check to see if anything was generated, if not default to the concept's text or empty string if that doesnt exist

--- a/packages/utils/src/atoms/codeable-concept.ts
+++ b/packages/utils/src/atoms/codeable-concept.ts
@@ -1,14 +1,17 @@
 import { CodeableConcept, Maybe } from '@ltht-react/types'
 
-const codeableConceptDisplaySummary = (codeableConcept: Maybe<CodeableConcept> = {}, codingSystem?: string): string => {
+const codeableConceptDisplaySummary = (
+  codeableConcept: Maybe<CodeableConcept> = {},
+  codingSystemFilter?: string
+): string => {
   const codings = codeableConcept?.coding || []
 
   // Get a list of codings if are available
   // An empty array, or array of codings that don't have the display property set will return empty string
   let display = codings.map((coding) => coding?.display).join(', ')
 
-  if (codingSystem) {
-    const filteredCodings = codings.filter((coding) => coding?.system === codingSystem)
+  if (codingSystemFilter) {
+    const filteredCodings = codings.filter((coding) => coding?.system === codingSystemFilter)
     display = filteredCodings.map((coding) => coding?.display).join(', ')
   }
 

--- a/packages/utils/src/atoms/codeable-concept.ts
+++ b/packages/utils/src/atoms/codeable-concept.ts
@@ -1,11 +1,16 @@
 import { CodeableConcept, Maybe } from '@ltht-react/types'
 
-const codeableConceptDisplaySummary = (codeableConcept: Maybe<CodeableConcept> = {}): string => {
+const codeableConceptDisplaySummary = (codeableConcept: Maybe<CodeableConcept> = {}, codingSystem?: string): string => {
   const codings = codeableConcept?.coding || []
 
   // Get a list of codings if are available
   // An empty array, or array of codings that don't have the display property set will return empty string
   let display = codings.map((coding) => coding?.display).join(', ')
+
+  if (codingSystem) {
+    const filteredCodings = codings.filter((coding) => coding?.system === codingSystem)
+    display = filteredCodings.map((coding) => coding?.display).join(', ')
+  }
 
   // Check to see if anything was generated, if not default to the concept's text or empty string if that doesnt exist
   if (display?.length === 0) {


### PR DESCRIPTION
Added parameter codingSystemFilter to Diagnosis Summary so that we can filter out any condition codes that match the codingSystemFilter when we built the title text for the items in the Diagnosis list view.

This way we can filter out the replacement code mapping so that it doesn't appear in the title and show two conditions for conditions that have a replacement coding