### PR TITLE
Filter invalid children before cloning

### DIFF
--- a/components/clinical/shared/type-detail/src/organisms/collapsible-detail-collection.tsx
+++ b/components/clinical/shared/type-detail/src/organisms/collapsible-detail-collection.tsx
@@ -1,4 +1,4 @@
-import { FC, Children, cloneElement } from 'react'
+import { FC, Children, cloneElement, ReactNode, isValidElement } from 'react'
 import styled from '@emotion/styled'
 import { DetailViewType, Maybe } from '@ltht-react/types'
 import { DESKTOP_MINIMUM_MEDIA_QUERY, MOBILE_MAXIMUM_MEDIA_QUERY, TABLET_ONLY_MEDIA_QUERY } from '@ltht-react/styles'
@@ -48,14 +48,20 @@ const CollapsibleDetailCollection: FC<CollapsibleDetailCollectionProps> = ({ chi
 
   return (
     <StyledCollapsibleDetailCollection>
-      {Children.map(children, (child) => cloneElement(child, { showIfEmpty }))}
+      {Children.toArray(children)
+        .filter(isValidElement<CollapsibleDetailChildProps>)
+        .map((child) => cloneElement(child, { showIfEmpty }))}
     </StyledCollapsibleDetailCollection>
   )
 }
+
 export interface CollapsibleDetailCollectionProps {
   viewType?: Maybe<DetailViewType>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  children?: any
+  children?: ReactNode
+}
+
+export interface CollapsibleDetailChildProps {
+  showIfEmpty?: boolean
 }
 
 export default CollapsibleDetailCollection

--- a/packages/storybook/src/ui/organisms/collapsible-detail-collection/collapsible-detail-collection.stories.tsx
+++ b/packages/storybook/src/ui/organisms/collapsible-detail-collection/collapsible-detail-collection.stories.tsx
@@ -1,29 +1,34 @@
 import Card from '@ltht-react/card'
 import DiagnosisDetail from '@ltht-react/diagnosis-detail'
-import { CollapsibleDetailCollection } from '@ltht-react/type-detail'
+import { CollapsibleDetailCollection, StringDetail } from '@ltht-react/type-detail'
 import { DetailViewType } from '@ltht-react/types'
-import { Story } from '@storybook/react'
+import { StoryFn } from '@storybook/react'
 
 import { Hemophilia } from './collapsible-detail-collection.fixtures'
 
-export const Expanded: Story = () => (
-  <Card>
-    <Card.Header>
-      <Card.Title>Expanded collection view</Card.Title>
-    </Card.Header>
-    <Card.Body>
-      <p>
-        Expanded view will show every Detail component, regardless of whether it has a value or not. This means that the
-        Detail component will just show the term
-      </p>
-      <CollapsibleDetailCollection viewType={DetailViewType.Expanded}>
-        <DiagnosisDetail condition={Hemophilia} viewType={DetailViewType.Expanded} />
-      </CollapsibleDetailCollection>
-    </Card.Body>
-  </Card>
-)
+export const Expanded: StoryFn = () => {
+  const showExtraDetails = false
 
-export const Compact: Story = () => (
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title>Expanded collection view</Card.Title>
+      </Card.Header>
+      <Card.Body>
+        <p>
+          Expanded view will show every Detail component, regardless of whether it has a value or not. This means that
+          the Detail component will just show the term
+        </p>
+        <CollapsibleDetailCollection viewType={DetailViewType.Expanded}>
+          <DiagnosisDetail condition={Hemophilia} viewType={DetailViewType.Expanded} />
+          {showExtraDetails && <StringDetail term="Extra Details" />}
+        </CollapsibleDetailCollection>
+      </Card.Body>
+    </Card>
+  )
+}
+
+export const Compact: StoryFn = () => (
   <Card>
     <Card.Header>
       <Card.Title>Compact collection view</Card.Title>


### PR DESCRIPTION
We are working on the ability to import external diagnoses into PPM+, before import we wish to show details of the diagnosis before the user initiates the import. Part of the requirements is to conditionally display the original condition and a mapped condition should there not be an exact match. Conditionally rendering an element inside the CollapsibleDetailCollection 

```
<CollapsibleDetailCollection>
  <StringDetail term={conditionTitle} description={originalCodeDisplay} />
  {hasReplacementCodeMapping && <StringDetail term={mappedDiagnosisTitle} description={mappedCodeDisplay} />}
</CollapsibleDetailCollection>
```

Causes an exception to be thrown, in this case when `hasReplacementCodeMapping` is false. This is because the false value is then passed down to the `cloneElement` method which throws an exception because false is not a valid element.

`{Children.map(children, (child) => cloneElement(child, { showIfEmpty }))}`

We have introduced a call to 

`Children.toArray(children)`

 this will filter out , null, undefined, false etc and then we have further call to 
 
 `.filter(isValidElement<CollapsibleDetailChildProps>)`
 
 This will filter out anything that is not a valid React Element. We have had to introduce the `CollapsibleDetailChildProps` interface to keep the compiler happy after the call to isValidElement.