### PR TITLE
Allow widget body to fill space of parent container

### DIFF
--- a/components/styled/card/src/atoms/body.tsx
+++ b/components/styled/card/src/atoms/body.tsx
@@ -5,8 +5,8 @@ import styled from '@emotion/styled'
 const StyledBody = styled.div`
   flex: 1 1 auto;
   min-height: 1px;
-  padding: 0.5rem 0.75rem 0.5rem 0;
-  margin: 0 0 0 0.75rem;
+  padding: 0.5rem 0.75rem;
+  margin: 0;
   border-top: 1px solid rgba(0, 0, 0, 0.125);
 `
 


### PR DESCRIPTION
When content is directly in a widget body e.g.

```
<Widget.Body>
  <NoDataMessage>No Records were found</NoDataMessage>
</Widget.Body>
```

There is a gap to the left of the content

![image](https://github.com/user-attachments/assets/514bde94-90d7-4cec-b9a5-ac1b53aa1fc7)

If the content is within a widget list / widget list item e.g.

```
<Widget.List>
  <Widget.ListItem>
    <NoDataMessage>{text}</NoDataMessage>
  </Widget.ListItem>
</Widget.List>
```

The issue is not present

![image](https://github.com/user-attachments/assets/4aab7c38-6ddb-46cf-ac55-c36a6d19d84d)
