### PR TITLE
Allow widget body content to fill space of parent container

### DIFF
--- a/components/clinical/allergy-detail/src/index.tsx
+++ b/components/clinical/allergy-detail/src/index.tsx
@@ -25,11 +25,10 @@ const TopSection = styled.div`
   }
 `
 
-const Seperator = styled.div`
+const Separator = styled.div`
   height: 1px;
   background: rgba(0, 0, 0, 0.125);
-  width: calc(100% + 12px);
-  margin: 1rem 0;
+  margin: 0.75rem -0.75rem 0 -0.75rem;
 `
 
 const AllergyDetail: FC<Props> = ({ allergy, showDates = true, viewType = DetailViewType.Compact }) => (
@@ -38,7 +37,7 @@ const AllergyDetail: FC<Props> = ({ allergy, showDates = true, viewType = Detail
       <StringDetail term="Type" description={allergy.type?.toString()} />
       <CodingListDetail term="Data Source(s)" codings={allergy.metadata.dataSources} />
     </TopSection>
-    <Seperator />
+    <Separator />
     <CollapsibleDetailCollection viewType={viewType}>
       <StringDetail term="Category" description={allergy?.category?.toString()} />
       <CodeableConceptDetail term="Allergy" concept={allergy.code} />

--- a/components/clinical/diagnosis-detail/src/organisms/diagnosis-detail.tsx
+++ b/components/clinical/diagnosis-detail/src/organisms/diagnosis-detail.tsx
@@ -27,8 +27,7 @@ const TopSection = styled.div`
 const Separator = styled.div`
   height: 1px;
   background: rgba(0, 0, 0, 0.125);
-  width: calc(100% + 12px);
-  margin: 1rem 0;
+  margin: 0.75rem -0.75rem 0 -0.75rem;
 `
 
 const DiagnosisDetail: FC<Props> = ({

--- a/components/clinical/medication-detail/src/index.tsx
+++ b/components/clinical/medication-detail/src/index.tsx
@@ -16,11 +16,10 @@ import { FC } from 'react'
 
 const TopSection = styled.div``
 
-const Seperator = styled.div`
+const Separator = styled.div`
   height: 1px;
   background: rgba(0, 0, 0, 0.125);
-  width: calc(100% + 12px);
-  margin: 1rem 0;
+  margin: 0.75rem -0.75rem 0 -0.75rem;
 `
 
 const MedicationDetail: FC<IProps> = ({ medication, viewType = DetailViewType.Compact }) => {
@@ -48,7 +47,7 @@ const MedicationDetail: FC<IProps> = ({ medication, viewType = DetailViewType.Co
         <StringDetail term="Status at Discharge" description={status} />
         <AnnotationListDetail term="Changes / Comments" notes={medication?.note} />
       </TopSection>
-      <Seperator />
+      <Separator />
       <CollapsibleDetailCollection viewType={viewType}>
         <CodeableConceptDetail term="Medication" concept={medication?.medicationReference?.code} />
         <NestedListDetail term="Dosage" className={medicationClasses}>

--- a/components/styled/card/src/atoms/body.tsx
+++ b/components/styled/card/src/atoms/body.tsx
@@ -5,8 +5,8 @@ import styled from '@emotion/styled'
 const StyledBody = styled.div`
   flex: 1 1 auto;
   min-height: 1px;
-  padding: 0.5rem 0.75rem 0.5rem 0;
-  margin: 0 0 0 0.75rem;
+  padding: 0.75rem;
+  margin: 0;
   border-top: 1px solid rgba(0, 0, 0, 0.125);
 `
 

--- a/components/styled/card/src/atoms/header.tsx
+++ b/components/styled/card/src/atoms/header.tsx
@@ -3,8 +3,7 @@ import classNames from 'classnames'
 import styled from '@emotion/styled'
 
 const StyledHeader = styled.div`
-  padding: 0.75rem 0.75rem 0.75rem 0;
-  margin-left: 0.75rem;
+  padding: 0.75rem;
 `
 
 const Header: FC<Props> = ({ classes, children, ...rest }) => (


### PR DESCRIPTION
When content is directly in a widget body e.g.

```
<Widget.Body>
  <NoDataMessage>No Records were found</NoDataMessage>
</Widget.Body>
```

There is a gap to the left of the content

![image](https://github.com/user-attachments/assets/a3f2aa1e-77b8-44e6-b98a-f8720b29b493)

If the content is within a widget list / widget list item e.g.

```
<Widget.List>
  <Widget.ListItem>
    <NoDataMessage>{text}</NoDataMessage>
  </Widget.ListItem>
</Widget.List>
```

The issue is not present

![image](https://github.com/user-attachments/assets/91324a2f-53c5-4dc2-80d0-5c732a209cae)
