### PR TITLE
Move tags and badges to their own row

### DIFF
--- a/components/clinical/diagnosis-summary/src/atoms/diagnosis-onset-estimated.tsx
+++ b/components/clinical/diagnosis-summary/src/atoms/diagnosis-onset-estimated.tsx
@@ -11,6 +11,7 @@ const StyledOnsetEstimated = styled.div<IStyledDescription>`
   font-size: x-small;
   white-space: pre-wrap;
   display: inline-block;
+  text-align: right;
   text-decoration: ${({ enteredInError }) => (enteredInError ? 'line-through' : 'none')};
 `
 
@@ -22,7 +23,7 @@ const DiagnosisOnsetEstimated: FC<Props> = ({ condition, enteredInError, ...rest
 
   return (
     <StyledOnsetEstimated enteredInError={enteredInError} {...rest}>
-      {onsetDateEstimated ? ' (estimated)' : ''}
+      {onsetDateEstimated ? '(estimated)' : ''}
     </StyledOnsetEstimated>
   )
 }

--- a/components/clinical/diagnosis-summary/src/organisms/diagnosis-summary.tsx
+++ b/components/clinical/diagnosis-summary/src/organisms/diagnosis-summary.tsx
@@ -6,13 +6,7 @@ import { DateSummary } from '@ltht-react/type-summary'
 import Icon from '@ltht-react/icon'
 import { Button, ButtonProps } from '@ltht-react/button'
 
-import {
-  BTN_COLOURS,
-  DESKTOP_MINIMUM_MEDIA_QUERY,
-  SMALL_SCREEN_MAXIMUM_MEDIA_QUERY,
-  TABLET_MINIMUM_MEDIA_QUERY,
-  WIDESCREEN_MINIMUM_MEDIA_QUERY,
-} from '@ltht-react/styles'
+import { BTN_COLOURS, SMALL_SCREEN_MAXIMUM_MEDIA_QUERY, TABLET_MINIMUM_MEDIA_QUERY } from '@ltht-react/styles'
 import Title from '../atoms/diagnosis-title'
 import OnsetDateEstimated from '../atoms/diagnosis-onset-estimated'
 import Redacted from '../molecules/diagnosis-redacted'
@@ -106,9 +100,7 @@ const StyledResponsiveTagContainer = styled.div`
     padding: 0 10px;
     justify-content: center;
 
-    ${TABLET_MINIMUM_MEDIA_QUERY},
-    ${DESKTOP_MINIMUM_MEDIA_QUERY},
-    ${WIDESCREEN_MINIMUM_MEDIA_QUERY} {
+    ${TABLET_MINIMUM_MEDIA_QUERY} {
       font-size: 0.9rem !important;
     }
   }

--- a/components/clinical/diagnosis-summary/src/organisms/diagnosis-summary.tsx
+++ b/components/clinical/diagnosis-summary/src/organisms/diagnosis-summary.tsx
@@ -6,59 +6,128 @@ import { DateSummary } from '@ltht-react/type-summary'
 import Icon from '@ltht-react/icon'
 import { Button, ButtonProps } from '@ltht-react/button'
 
-import { BTN_COLOURS, SMALL_SCREEN_MAXIMUM_MEDIA_QUERY, WIDESCREEN_MINIMUM_MEDIA_QUERY } from '@ltht-react/styles'
+import {
+  BTN_COLOURS,
+  DESKTOP_MINIMUM_MEDIA_QUERY,
+  SMALL_SCREEN_MAXIMUM_MEDIA_QUERY,
+  TABLET_MINIMUM_MEDIA_QUERY,
+  WIDESCREEN_MINIMUM_MEDIA_QUERY,
+} from '@ltht-react/styles'
 import Title from '../atoms/diagnosis-title'
 import OnsetDateEstimated from '../atoms/diagnosis-onset-estimated'
 import Redacted from '../molecules/diagnosis-redacted'
 import DiagnosisDataSource from '../atoms/diagnosis-data-source'
 
 const StyledTitle = styled.div`
-  display: inline-block;
+  display: flex;
 `
+
 const StyledSummary = styled.div`
   display: flex;
   justify-content: center;
+  flex-direction: column;
 `
+
 const StyledDescription = styled.div`
   flex-grow: 1;
 `
-const StyledLeftContainer = styled.div`
+
+const StyledTitleAndDateContainer = styled.div`
   display: flex;
   flex-grow: 1;
-  flex-direction: column;
-  gap: 0.3rem;
+  flex-direction: row;
+  gap: 5px;
 
-  ${WIDESCREEN_MINIMUM_MEDIA_QUERY} {
-    flex-direction: row;
+  ${SMALL_SCREEN_MAXIMUM_MEDIA_QUERY} {
+    flex-flow: column nowrap;
+    align-items: flex-start;
+    div {
+      text-align: left;
+    }
   }
 `
-const StyledResponsiveContainer = styled.div`
-  display: flex;
-  margin: 0;
-  flex-flow: row wrap;
-  gap: 0.3rem;
-  align-content: center;
 
-  ${WIDESCREEN_MINIMUM_MEDIA_QUERY} {
-    margin: 0 10px 0 10px;
+const StyledButtonAndTagContainer = styled.div`
+  display: flex;
+  flex-grow: 1;
+  flex-direction: row;
+  gap: 5px;
+  margin-top: 0.5rem;
+
+  ${SMALL_SCREEN_MAXIMUM_MEDIA_QUERY} {
+    flex-direction: row;
+    justify-content: space-between;
+  }
+`
+
+const StyledResponsiveButtonContainer = styled.div`
+  display: flex;
+  margin-right: auto;
+  flex-flow: row wrap;
+  gap: 5px;
+  height: fit-content;
+  flex-grow: 1;
+
+  & > * {
+    height: 1.5rem;
+    padding: 0 5px;
+
+    ${TABLET_MINIMUM_MEDIA_QUERY} {
+      font-size: 0.9rem !important;
+    }
   }
 
   ${SMALL_SCREEN_MAXIMUM_MEDIA_QUERY} {
     margin: 0;
     flex-direction: column;
-    align-content: flex-start;
 
-    & > * {
+    span {
       width: 100%;
       max-width: 10rem;
     }
   }
 `
 
+const StyledResponsiveTagContainer = styled.div`
+  display: flex;
+  margin-left: auto;
+  flex-flow: row wrap;
+  gap: 5px;
+  height: fit-content;
+  justify-content: flex-end;
+  flex-grow: 1;
+
+  & > * {
+    display: flex;
+    align-items: center;
+    height: 1.5rem;
+    margin: 0 !important;
+    font-size: 0.8rem !important;
+    padding: 0 10px;
+    justify-content: center;
+
+    ${TABLET_MINIMUM_MEDIA_QUERY},
+    ${DESKTOP_MINIMUM_MEDIA_QUERY},
+    ${WIDESCREEN_MINIMUM_MEDIA_QUERY} {
+      font-size: 0.9rem !important;
+    }
+  }
+
+  ${SMALL_SCREEN_MAXIMUM_MEDIA_QUERY} {
+    flex-direction: column;
+    margin: 0;
+
+    & > * {
+      margin: 0;
+      width: 100%;
+      max-width: 10rem;
+      padding: 0 10px;
+    }
+  }
+`
+
 const StyledButton = styled(Button)`
-  font-size: 0.8rem !important;
-  padding: 1px 5px;
-  max-height: 1.5rem;
+  padding: 0 5px;
   width: fit-content;
 
   ${SMALL_SCREEN_MAXIMUM_MEDIA_QUERY} {
@@ -71,6 +140,7 @@ const StyledDate = styled.div`
   flex-flow: column nowrap;
   text-align: right;
   min-width: 6rem;
+  justify-content: start;
 `
 const IconButtonWrapper = styled(Button)`
   -webkit-box-align: center;
@@ -113,7 +183,7 @@ const DiagnosisSummary: FC<Props> = ({
 
   return (
     <StyledSummary {...rest}>
-      <StyledLeftContainer>
+      <StyledTitleAndDateContainer>
         <StyledDescription>
           <StyledTitle>
             <Title
@@ -121,51 +191,50 @@ const DiagnosisSummary: FC<Props> = ({
               condition={condition}
               systemExclusionsFilter={systemExclusionsFilter}
             />
-          </StyledTitle>
-          {extensionTemplateDisplayName && !isReadOnly && canExtendDiagnosis && !enteredInError && (
-            <IconButtonWrapper
-              onClick={extensionClickHandler}
-              type="button"
-              styling={{ buttonStyle: 'clear' }}
-              value=""
-              icon={<Icon type="folder-plus" size="medium" />}
-              iconPlacement="center"
-              iconColour={BTN_COLOURS.PRIMARY.VALUE}
-              title={`This diagnosis can be extended further using form '${extensionTemplateDisplayName}' by clicking here`}
-            />
-          )}
-          {extendedTemplateDisplayName && (
-            <IconWrapper>
-              <Icon
-                type="comment"
-                size="medium"
-                title={`This diagnosis has been extended beyond standard diagnosis with form '${extendedTemplateDisplayName}'.
-           To view these extra details, click into the full diagnosis detail or edit the existing form.`}
+            {extensionTemplateDisplayName && !isReadOnly && canExtendDiagnosis && !enteredInError && (
+              <IconButtonWrapper
+                onClick={extensionClickHandler}
+                type="button"
+                styling={{ buttonStyle: 'clear' }}
+                value=""
+                icon={<Icon type="folder-plus" size="medium" />}
+                iconPlacement="center"
+                iconColour={BTN_COLOURS.PRIMARY.VALUE}
+                title={`This diagnosis can be extended further using form '${extensionTemplateDisplayName}' by clicking here`}
               />
-            </IconWrapper>
-          )}
-
+            )}
+            {extendedTemplateDisplayName && (
+              <IconWrapper>
+                <Icon
+                  type="comment"
+                  size="medium"
+                  title={`This diagnosis has been extended beyond standard diagnosis with form '${extendedTemplateDisplayName}'.
+           To view these extra details, click into the full diagnosis detail or edit the existing form.`}
+                />
+              </IconWrapper>
+            )}
+          </StyledTitle>
           {displaySource && <DiagnosisDataSource condition={condition} enteredInError={enteredInError} />}
         </StyledDescription>
+        <StyledDate>
+          <DateSummary enteredInError={enteredInError} datetime={condition?.assertedDate} dateOnlyView={dateOnlyView} />
+          <OnsetDateEstimated enteredInError={enteredInError} condition={condition} />
+        </StyledDate>
+      </StyledTitleAndDateContainer>
 
-        {tags.length > 0 && (
-          <StyledResponsiveContainer>
-            {tags?.map((tag, index) => (tag.key ? tag : cloneElement(tag, { key: index })))}
-          </StyledResponsiveContainer>
-        )}
-
-        {!isReadOnly && controls.length > 0 && (
-          <StyledResponsiveContainer>
+      {!isReadOnly && (controls.length > 0 || tags.length > 0) && (
+        <StyledButtonAndTagContainer>
+          <StyledResponsiveButtonContainer>
             {controls.map((props, index) => (
               <StyledButton key={index} {...props} />
             ))}
-          </StyledResponsiveContainer>
-        )}
-      </StyledLeftContainer>
-      <StyledDate>
-        <DateSummary enteredInError={enteredInError} datetime={condition?.assertedDate} dateOnlyView={dateOnlyView} />
-        <OnsetDateEstimated enteredInError={enteredInError} condition={condition} />
-      </StyledDate>
+          </StyledResponsiveButtonContainer>
+
+          <StyledResponsiveTagContainer>
+            {tags?.map((tag, index) => (tag.key ? tag : cloneElement(tag, { key: index })))}
+          </StyledResponsiveTagContainer>
+        </StyledButtonAndTagContainer>
+      )}
     </StyledSummary>
   )
 }

--- a/packages/storybook/src/clinical/organisms/diagnosis/diagnosis-with-split-view.stories.tsx
+++ b/packages/storybook/src/clinical/organisms/diagnosis/diagnosis-with-split-view.stories.tsx
@@ -1,0 +1,106 @@
+import { StoryFn } from '@storybook/react'
+
+import DiagnosisSummary from '@ltht-react/diagnosis-summary'
+import Card from '@ltht-react/card'
+import styled from '@emotion/styled'
+import { conditions, controls, tags } from './diagnosis.fixtures'
+
+const StyledSplitViewContainer = styled.div`
+  display: flex;
+  flex-grow: 1;
+  flex-direction: row;
+  position: relative;
+  height: 100%;
+  gap: 2rem;
+`
+
+const StyledPreviewPane = styled.div`
+  display: flex;
+  flex: 1;
+  margin-bottom: 0;
+
+  & > * {
+    flex-grow: 1;
+  }
+`
+
+const StyledMainPane = styled.div`
+  flex: 0 0 40%;
+  height: 100%;
+  max-height: 100%;
+`
+
+export const SummaryWithSplitView: StoryFn = () => {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  const clickHandler = (): void => {}
+
+  return (
+    <StyledSplitViewContainer>
+      <StyledMainPane>
+        <Card>
+          <Card.Header>
+            <Card.Title>Problems & Diagnosis</Card.Title>
+          </Card.Header>
+          <Card.List>
+            {conditions.map((condition, idx) => (
+              <Card.ListItem key={condition.id} onClick={clickHandler}>
+                {idx === 0 && (
+                  <DiagnosisSummary
+                    isReadOnly
+                    condition={condition}
+                    extendedTemplateDisplayName="Diagnosis Generic Cancer Level Two"
+                    displaySource
+                  />
+                )}
+                {idx === 1 && (
+                  <DiagnosisSummary
+                    condition={condition}
+                    extensionTemplateDisplayName="Diagnosis Generic Cancer Level Two"
+                    extensionClickHandler={clickHandler}
+                    isReadOnly={false}
+                    tags={tags}
+                    controls={controls}
+                    displaySource
+                  />
+                )}
+                {idx === 2 && <DiagnosisSummary condition={condition} isReadOnly={false} />}
+                {idx === 3 && (
+                  <DiagnosisSummary
+                    condition={condition}
+                    extensionTemplateDisplayName="Diagnosis Generic Cancer Level Three"
+                    extendedTemplateDisplayName="Diagnosis Generic Cancer Level Two"
+                    extensionClickHandler={clickHandler}
+                    isReadOnly={false}
+                    controls={[controls[0]]}
+                    tags={[tags[0]]}
+                  />
+                )}
+                {idx === 4 && <DiagnosisSummary condition={condition} isReadOnly={false} />}
+                {idx === 5 && (
+                  <DiagnosisSummary
+                    condition={condition}
+                    extensionTemplateDisplayName="Diagnosis Generic Cancer Level Two"
+                    extensionClickHandler={clickHandler}
+                    isReadOnly
+                    controls={controls}
+                    tags={[tags[0]]}
+                  />
+                )}
+              </Card.ListItem>
+            ))}
+          </Card.List>
+        </Card>
+      </StyledMainPane>
+      <StyledPreviewPane>
+        <Card>
+          <Card.Header>
+            <Card.Title>Viewing: Diagnosis Level One</Card.Title>
+          </Card.Header>
+          <Card.List />
+        </Card>
+      </StyledPreviewPane>
+    </StyledSplitViewContainer>
+  )
+}
+
+export default { title: 'Clinical/Organisms/Diagnosis' }

--- a/packages/storybook/src/clinical/organisms/diagnosis/diagnosis.fixtures.tsx
+++ b/packages/storybook/src/clinical/organisms/diagnosis/diagnosis.fixtures.tsx
@@ -940,7 +940,6 @@ const controls: ButtonProps[] = [
     title: 'Description of the button action can go here!!!',
     styling: {
       buttonStyle: 'workflow',
-      padding: '20px',
     },
   },
   {
@@ -948,7 +947,6 @@ const controls: ButtonProps[] = [
     value: 'Control 2',
     styling: {
       buttonStyle: 'standard',
-      padding: '2px 10px',
     },
   },
   {
@@ -956,7 +954,6 @@ const controls: ButtonProps[] = [
     value: 'Control 3',
     styling: {
       buttonStyle: 'danger',
-      padding: '2px 10px',
     },
   },
   {
@@ -964,7 +961,6 @@ const controls: ButtonProps[] = [
     value: 'Control 4',
     styling: {
       buttonStyle: 'primary',
-      padding: '2px 10px',
     },
   },
   {
@@ -973,7 +969,6 @@ const controls: ButtonProps[] = [
     value: 'Control 5',
     styling: {
       buttonStyle: 'clear',
-      padding: '2px 10px',
     },
   },
 ]


### PR DESCRIPTION
This is an attempt to improve the responsiveness of the diagnosis summary view, especially when used in small spaces such as a split view with a form open. We were finding that the widget did not collapse before content overflowed widget:

![image](https://github.com/user-attachments/assets/d50ba8c3-00b8-4529-955a-f2293ac3e99c)

![image](https://github.com/user-attachments/assets/f3cdd502-630a-45e7-b9dd-0f633caa0982)

We ameliorated this issue a little by enforcing a single column at a viewport anything below widescreen but felt we could still further improve the widget itself. The buttons and tags have now been move on to their own row rather than between the title and the date:

![image](https://github.com/user-attachments/assets/b383e0c1-b14a-45ca-969d-17bea052ba48)

This is still able to collapse down on small screens

![image](https://github.com/user-attachments/assets/9573953c-3a25-4bfb-b416-f3fbe5893098)

Apart from the layout changes I've also made changes to the styling because there seem to be a number of inconsistencies, mainly in margins and font-sizes.

![DifferentSpacing](https://github.com/user-attachments/assets/8b3fdb9b-2f87-4638-8d8f-dfe819d32afb)

![DifferentFontSizes](https://github.com/user-attachments/assets/0d90a1eb-cba1-4d86-b33a-1df50c4577ed)

I've tried to avoid making changes to the badges or buttons themselves to get consistency although I really feel like we have some odd styling (e.g. badge has 0.1em top margin for some reason), font sizes also differ because buttons use the CSS_RESET but badges don't.