### PR TITLE
Standardise date packages

### DIFF
--- a/components/clinical/hospital-stay-summary/package.json
+++ b/components/clinical/hospital-stay-summary/package.json
@@ -29,7 +29,7 @@
     "@ltht-react/type-summary": "^2.0.159",
     "@ltht-react/types": "^2.0.159",
     "@ltht-react/utils": "^2.0.159",
-    "date-fns": "^4.1.0",
+    "date-fns": "^3.6.0",
     "react": "^18.2.0"
   },
   "gitHead": "4d364556bb11e294d86697c2dac66742f7aabc7f"

--- a/components/clinical/hospital-stay-summary/package.json
+++ b/components/clinical/hospital-stay-summary/package.json
@@ -29,7 +29,7 @@
     "@ltht-react/type-summary": "^2.0.159",
     "@ltht-react/types": "^2.0.159",
     "@ltht-react/utils": "^2.0.159",
-    "moment": "^2.30.1",
+    "date-fns": "^4.1.0",
     "react": "^18.2.0"
   },
   "gitHead": "4d364556bb11e294d86697c2dac66742f7aabc7f"

--- a/components/clinical/hospital-stay-summary/src/atoms/admission-length-of-stay.tsx
+++ b/components/clinical/hospital-stay-summary/src/atoms/admission-length-of-stay.tsx
@@ -1,9 +1,9 @@
 import { HTMLAttributes, FC } from 'react'
 import styled from '@emotion/styled'
+import { formatDistance } from 'date-fns'
 
 import { TEXT_COLOURS } from '@ltht-react/styles'
 import { Encounter } from '@ltht-react/types'
-import * as moment from 'moment'
 
 const StyledLengthOfStayText = styled.div`
   color: ${TEXT_COLOURS.INFO};
@@ -15,11 +15,8 @@ const StyledLengthOfStayText = styled.div`
 
 const AdmissionLengthOfStay: FC<Props> = ({ encounter, ...rest }) => {
   if (encounter.length?.value) {
-    return (
-      <StyledLengthOfStayText {...rest}>
-        Length of Stay: {moment.duration(encounter.length?.value ?? 0, 'minutes').humanize()}
-      </StyledLengthOfStayText>
-    )
+    const milliseconds = (encounter?.length?.value ?? 0) * 60000
+    return <StyledLengthOfStayText {...rest}>Length of Stay: {formatDistance(milliseconds, 0)}</StyledLengthOfStayText>
   }
 
   return null

--- a/components/clinical/shared/type-summary/package.json
+++ b/components/clinical/shared/type-summary/package.json
@@ -34,7 +34,7 @@
     "@ltht-react/styles": "^2.0.159",
     "@ltht-react/types": "^2.0.159",
     "@ltht-react/utils": "^2.0.159",
-    "date-fns": "^4.1.0",
+    "date-fns": "^3.6.0",
     "react": "^18.2.0"
   },
   "gitHead": "4d364556bb11e294d86697c2dac66742f7aabc7f"

--- a/components/clinical/shared/type-summary/package.json
+++ b/components/clinical/shared/type-summary/package.json
@@ -34,7 +34,7 @@
     "@ltht-react/styles": "^2.0.159",
     "@ltht-react/types": "^2.0.159",
     "@ltht-react/utils": "^2.0.159",
-    "date-fns": "^2.22.1",
+    "date-fns": "^4.1.0",
     "react": "^18.2.0"
   },
   "gitHead": "4d364556bb11e294d86697c2dac66742f7aabc7f"

--- a/components/styled/input/package.json
+++ b/components/styled/input/package.json
@@ -34,7 +34,7 @@
     "@ltht-react/types": "^2.0.159",
     "@ltht-react/utils": "^2.0.159",
     "@popperjs/core": "^2.11.5",
-    "date-fns": "^2.22.1",
+    "date-fns": "^4.1.0",
     "focus-trap-react": "^9.0.2",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",

--- a/components/styled/input/package.json
+++ b/components/styled/input/package.json
@@ -34,7 +34,7 @@
     "@ltht-react/types": "^2.0.159",
     "@ltht-react/utils": "^2.0.159",
     "@popperjs/core": "^2.11.5",
-    "date-fns": "^4.1.0",
+    "date-fns": "^3.6.0",
     "focus-trap-react": "^9.0.2",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -92,7 +92,7 @@
     "@testing-library/jest-dom": "^6.2.0",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.5.2",
-    "date-fns": "^2.22.1",
+    "date-fns": "^4.1.0",
     "react": "^18.2.0",
     "react-day-picker": "^8.9.1",
     "react-dom": "^18.2.0"

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -92,7 +92,7 @@
     "@testing-library/jest-dom": "^6.2.0",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.5.2",
-    "date-fns": "^4.1.0",
+    "date-fns": "^3.6.0",
     "react": "^18.2.0",
     "react-day-picker": "^8.9.1",
     "react-dom": "^18.2.0"

--- a/packages/storybook/src/clinical/organisms/hospital-stays/hospital-stays.test.tsx
+++ b/packages/storybook/src/clinical/organisms/hospital-stays/hospital-stays.test.tsx
@@ -18,7 +18,7 @@ describe('Hospital Stays', () => {
 
     it('Renders Length Of Stay', () => {
       render(<AdmissionSummary admission={admissions[0]} />)
-      expect(screen.getByText('Length of Stay: 6 hours')).toBeVisible()
+      expect(screen.getByText('Length of Stay: about 6 hours')).toBeVisible()
     })
   })
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@ltht-react/styles": "^2.0.159",
     "@ltht-react/types": "^2.0.159",
-    "date-fns": "^4.1.0",
+    "date-fns": "^3.6.0",
     "html-react-parser": "^5.0.6"
   },
   "gitHead": "4d364556bb11e294d86697c2dac66742f7aabc7f"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@ltht-react/styles": "^2.0.159",
     "@ltht-react/types": "^2.0.159",
-    "date-fns": "^2.22.1",
+    "date-fns": "^4.1.0",
     "html-react-parser": "^5.0.6"
   },
   "gitHead": "4d364556bb11e294d86697c2dac66742f7aabc7f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1168,7 +1168,7 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.21.0", "@babel/runtime@^7.23.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.23.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.23.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.5.tgz#11edb98f8aeec529b82b211028177679144242db"
   integrity sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==
@@ -7296,12 +7296,10 @@ dataloader@^2.2.2:
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.2.2.tgz#216dc509b5abe39d43a9b9d97e6e5e473dfbe3e0"
   integrity sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==
 
-date-fns@^2.22.1:
-  version "2.30.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
-  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
-  dependencies:
-    "@babel/runtime" "^7.21.0"
+date-fns@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
 
 dateformat@^3.0.0:
   version "3.0.3"
@@ -11846,11 +11844,6 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
-
-moment@^2.30.1:
-  version "2.30.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
-  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
 mri@^1.2.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7296,10 +7296,10 @@ dataloader@^2.2.2:
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.2.2.tgz#216dc509b5abe39d43a9b9d97e6e5e473dfbe3e0"
   integrity sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==
 
-date-fns@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
-  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
+date-fns@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.6.0.tgz#f20ca4fe94f8b754951b24240676e8618c0206bf"
+  integrity sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==
 
 dateformat@^3.0.0:
   version "3.0.3"


### PR DESCRIPTION
Remove moment (big, slow, unsupported)
Upgrade date-fns from 2.x to ^3.6.0. Couldn't get 4.1.0 to work as Jest has issues transpiling the raw ESM modules it uses for localisation.

One minor change to output here as `AdmissionLengthOfStay` used moment to format a duration into a string.. 
Before - 123 mins => "2 hours"
After - 123 mins => "about 2 hours"

Probably better to be honest!