### PR TITLE
Add forwardRef support to Card and Card.* subcomponents

### DIFF
--- a/components/styled/banner/src/index.tsx
+++ b/components/styled/banner/src/index.tsx
@@ -1,4 +1,4 @@
-import { FC, HTMLAttributes, ReactNode } from 'react'
+import { FC, forwardRef, HTMLAttributes, ReactNode } from 'react'
 import styled from '@emotion/styled'
 import { BANNER_COLOURS, CSS_RESET } from '@ltht-react/styles'
 import Icon from '@ltht-react/icon'
@@ -90,8 +90,8 @@ const StyledIcon = styled.div`
 
 const canClick = (props: IBannerProps): boolean => props.onClick !== undefined
 
-const Banner: FC<IBannerProps> = ({ type = 'info', icon, children, ...rest }) => (
-  <StyledBanner {...rest} type={type} canClick={canClick(rest)}>
+const Banner = forwardRef<HTMLDivElement, IBannerProps>(({ type = 'info', icon, children, ...rest }, ref) => (
+  <StyledBanner ref={ref} {...rest} type={type} canClick={canClick(rest)}>
     {icon ? (
       <StyledIcon>{icon}</StyledIcon>
     ) : (
@@ -104,7 +104,7 @@ const Banner: FC<IBannerProps> = ({ type = 'info', icon, children, ...rest }) =>
     <BannerContent>{children}</BannerContent>
     {canClick(rest) && <Icon type="chevron" size="medium" direction="right" />}
   </StyledBanner>
-)
+))
 
 export const ButtonBanner: FC<IButtonBannerProps> = ({
   type = 'info',

--- a/components/styled/card/src/atoms/banner.tsx
+++ b/components/styled/card/src/atoms/banner.tsx
@@ -1,12 +1,12 @@
-import { HTMLAttributes, FC, ReactNode } from 'react'
+import { HTMLAttributes, ReactNode, forwardRef } from 'react'
 import Banner from '@ltht-react/banner'
 import { StatusTypes } from '@ltht-react/types'
 
-const CardBanner: FC<Props> = ({ status = 'info', icon, children, ...rest }) => (
-  <Banner type={status} icon={icon} {...rest}>
+const CardBanner = forwardRef<HTMLDivElement, Props>(({ status = 'info', icon, children, ...rest }, ref) => (
+  <Banner ref={ref} type={status} icon={icon} {...rest}>
     {children}
   </Banner>
-)
+))
 
 export interface Props extends HTMLAttributes<HTMLDivElement> {
   status: StatusTypes

--- a/components/styled/card/src/atoms/body.tsx
+++ b/components/styled/card/src/atoms/body.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes, FC } from 'react'
+import { HTMLAttributes, forwardRef } from 'react'
 import classNames from 'classnames'
 import styled from '@emotion/styled'
 
@@ -10,11 +10,11 @@ const StyledBody = styled.div`
   border-top: 1px solid rgba(0, 0, 0, 0.125);
 `
 
-const Body: FC<Props> = ({ classes, children, ...rest }) => (
-  <StyledBody className={classNames('card__body', classes)} {...rest}>
+const Body = forwardRef<HTMLDivElement, Props>(({ classes, children, ...rest }, ref) => (
+  <StyledBody ref={ref} className={classNames('card__body', classes)} {...rest}>
     {children}
   </StyledBody>
-)
+))
 
 export interface Props extends HTMLAttributes<HTMLDivElement> {
   classes?: string

--- a/components/styled/card/src/atoms/footer.tsx
+++ b/components/styled/card/src/atoms/footer.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes, FC } from 'react'
+import { HTMLAttributes, forwardRef } from 'react'
 import classNames from 'classnames'
 import styled from '@emotion/styled'
 
@@ -7,11 +7,11 @@ const StyledFooter = styled.div`
   border-top: 1px solid rgba(0, 0, 0, 0.125);
 `
 
-const Footer: FC<Props> = ({ classes, children, ...rest }) => (
-  <StyledFooter className={classNames('card__footer', classes)} {...rest}>
+const Footer = forwardRef<HTMLDivElement, Props>(({ classes, children, ...rest }, ref) => (
+  <StyledFooter ref={ref} className={classNames('card__footer', classes)} {...rest}>
     {children}
   </StyledFooter>
-)
+))
 
 export interface Props extends HTMLAttributes<HTMLDivElement> {
   classes?: string

--- a/components/styled/card/src/atoms/header.tsx
+++ b/components/styled/card/src/atoms/header.tsx
@@ -1,4 +1,4 @@
-import { FC, HTMLAttributes } from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import classNames from 'classnames'
 import styled from '@emotion/styled'
 
@@ -6,11 +6,11 @@ const StyledHeader = styled.div`
   padding: 0.75rem;
 `
 
-const Header: FC<Props> = ({ classes, children, ...rest }) => (
-  <StyledHeader className={classNames('card__header', classes)} {...rest}>
+const Header = forwardRef<HTMLDivElement, Props>(({ classes, children, ...rest }, ref) => (
+  <StyledHeader ref={ref} className={classNames('card__header', classes)} {...rest}>
     {children}
   </StyledHeader>
-)
+))
 
 export interface Props extends HTMLAttributes<HTMLDivElement> {
   classes?: string

--- a/components/styled/card/src/atoms/list-item.tsx
+++ b/components/styled/card/src/atoms/list-item.tsx
@@ -1,4 +1,4 @@
-import { FC, HTMLAttributes } from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import classNames from 'classnames'
 import styled from '@emotion/styled'
 import Icon from '@ltht-react/icon'
@@ -69,16 +69,16 @@ const StyledListItem = styled.li`
   }
 `
 
-const ListItem: FC<Props> = (props) => {
+const ListItem = forwardRef<HTMLLIElement, Props>((props, ref) => {
   const { classes, children, ...rest } = props
   const suffix = props?.selected === true ? '-selected' : ''
   return (
-    <StyledListItem className={classNames(`card__list-item${suffix}`, classes)} {...rest}>
+    <StyledListItem ref={ref} className={classNames(`card__list-item${suffix}`, classes)} {...rest}>
       <div className="card__list-item-container">{children}</div>
       {shouldClick(props) && <Icon type="chevron" size="medium" direction="right" />}
     </StyledListItem>
   )
-}
+})
 
 export interface Props extends HTMLAttributes<HTMLLIElement> {
   classes?: string

--- a/components/styled/card/src/atoms/list.tsx
+++ b/components/styled/card/src/atoms/list.tsx
@@ -1,4 +1,4 @@
-import { FC, HTMLAttributes } from 'react'
+import { forwardRef, HTMLAttributes } from 'react'
 import classNames from 'classnames'
 import styled from '@emotion/styled'
 
@@ -13,11 +13,11 @@ const StyledList = styled.ul`
   list-style-type: none;
 `
 
-const List: FC<Props> = ({ classes, children, ...rest }) => (
-  <StyledList className={classNames('card__list', classes)} {...rest}>
+const List = forwardRef<HTMLUListElement, Props>(({ classes, children, ...rest }, ref) => (
+  <StyledList ref={ref} className={classNames('card__list', classes)} {...rest}>
     {children}
   </StyledList>
-)
+))
 
 export interface Props extends HTMLAttributes<HTMLUListElement> {
   classes?: string

--- a/components/styled/card/src/index.tsx
+++ b/components/styled/card/src/index.tsx
@@ -1,4 +1,4 @@
-import { FC, HTMLAttributes } from 'react'
+import { FC, forwardRef, HTMLAttributes } from 'react'
 import classNames from 'classnames'
 import styled from '@emotion/styled'
 import { CSS_RESET, TEXT_COLOURS, CARD_BACKGROUND_COLOUR } from '@ltht-react/styles'
@@ -34,11 +34,11 @@ const StyledCard = styled.div`
   }
 `
 
-const Card: FC<CardProps> & CardComposition = ({ textAlign = 'left', classes, children, ...rest }) => (
-  <StyledCard textAlign={textAlign} className={classNames('card', classes)} {...rest}>
+const Card = forwardRef<HTMLDivElement, CardProps>(({ textAlign = 'left', classes, children, ...rest }, ref) => (
+  <StyledCard ref={ref} textAlign={textAlign} className={classNames('card', classes)} {...rest}>
     {children}
   </StyledCard>
-)
+)) as ForwardRefReturn<HTMLDivElement, CardProps> & CardComposition
 
 Card.Banner = Banner
 Card.Body = Body
@@ -50,13 +50,15 @@ Card.Subtitle = Subtitle
 Card.Text = Text
 Card.Title = Title
 
+type ForwardRefReturn<Element extends HTMLElement, Props> = ReturnType<typeof forwardRef<Element, Props>>
+
 interface CardComposition {
-  Banner: FC<BannerProps>
-  Body: FC<BodyProps>
-  Footer: FC<FooterProps>
-  Header: FC<HeaderProps>
-  ListItem: FC<ListItemProps>
-  List: FC<ListProps>
+  Banner: ForwardRefReturn<HTMLDivElement, BannerProps>
+  Body: ForwardRefReturn<HTMLDivElement, BodyProps>
+  Footer: ForwardRefReturn<HTMLDivElement, FooterProps>
+  Header: ForwardRefReturn<HTMLDivElement, HeaderProps>
+  ListItem: ForwardRefReturn<HTMLLIElement, ListItemProps>
+  List: ForwardRefReturn<HTMLUListElement, ListProps>
   Subtitle: FC<SubtitleProps>
   Text: FC<TextProps>
   Title: FC<TitleProps>

--- a/components/styled/icon/src/organisms/icon.tsx
+++ b/components/styled/icon/src/organisms/icon.tsx
@@ -58,6 +58,9 @@ import {
   faCircleMinus,
   faCircleXmark,
   faThumbsDown,
+  faExpand,
+  faExpandAlt,
+  faExpandArrowsAlt,
 } from '@fortawesome/free-solid-svg-icons'
 import { Transform } from '@fortawesome/fontawesome-svg-core'
 import CounterIcon from '../molecules/counter-icon'
@@ -367,6 +370,18 @@ const Icon: FC<IconProps> = ({
     }
     case 'cross-circle': {
       icon = faCircleXmark
+      break
+    }
+    case 'expand': {
+      icon = faExpand
+      break
+    }
+    case 'expand-alt': {
+      icon = faExpandAlt
+      break
+    }
+    case 'expand-arrows-alt': {
+      icon = faExpandArrowsAlt
       break
     }
 

--- a/packages/storybook/src/ui/molecules/banner/banner.test.tsx
+++ b/packages/storybook/src/ui/molecules/banner/banner.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 
 import Banner from '@ltht-react/banner'
+import { createRef } from 'react'
 
 describe('Banner', () => {
   it('Renders', () => {
@@ -11,5 +12,67 @@ describe('Banner', () => {
     )
 
     expect(screen.getByText('Child Element')).toBeInTheDocument()
+  })
+
+  it('Renders with type "info"', () => {
+    render(
+      <Banner type="info">
+        <div>Info Banner</div>
+      </Banner>
+    )
+    const banner = screen.getByText('Info Banner')
+    expect(banner).toBeInTheDocument()
+  })
+
+  it('Renders with a custom icon', () => {
+    const CustomIcon = () => <span data-testid="custom-icon">Icon</span>
+    render(
+      <Banner icon={<CustomIcon />}>
+        <div>Banner With Icon</div>
+      </Banner>
+    )
+    expect(screen.getByTestId('custom-icon')).toBeInTheDocument()
+    expect(screen.getByText('Banner With Icon')).toBeInTheDocument()
+  })
+
+  it('Renders with type "warning"', () => {
+    render(
+      <Banner type="warning">
+        <div>Warning Banner</div>
+      </Banner>
+    )
+    const banner = screen.getByText('Warning Banner')
+    expect(banner).toBeInTheDocument()
+  })
+
+  it('Renders with type "error"', () => {
+    render(
+      <Banner type="danger">
+        <div>Error Banner</div>
+      </Banner>
+    )
+    const banner = screen.getByText('Error Banner')
+    expect(banner).toBeInTheDocument()
+  })
+
+  it('Passes additional HTML attributes', () => {
+    render(
+      <Banner data-testid="banner-test" aria-label="test-banner">
+        <div>Attribute Banner</div>
+      </Banner>
+    )
+    const banner = screen.getByTestId('banner-test')
+    expect(banner).toHaveAttribute('aria-label', 'test-banner')
+  })
+
+  it('forwards ref to the root element', () => {
+    const ref = createRef<HTMLDivElement>()
+    render(
+      <Banner ref={ref}>
+        <div>Ref Banner</div>
+      </Banner>
+    )
+    expect(ref.current).toBeInstanceOf(HTMLDivElement)
+    expect(ref.current).toContainElement(screen.getByText('Ref Banner'))
   })
 })

--- a/packages/storybook/src/ui/molecules/icon/expand-icon.stories.tsx
+++ b/packages/storybook/src/ui/molecules/icon/expand-icon.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta, StoryObj } from '@storybook/react'
+import Icon from '@ltht-react/icon'
+
+const meta: Meta = {
+  component: Icon,
+}
+
+export default meta
+
+export const Small: StoryObj<typeof Icon> = {
+  render: () => <Icon type="expand" size="small" />,
+}
+export const Medium: StoryObj<typeof Icon> = {
+  render: () => <Icon type="expand" size="medium" />,
+}
+export const Large: StoryObj<typeof Icon> = {
+  render: () => <Icon type="expand" size="large" />,
+}

--- a/packages/storybook/src/ui/organisms/card/card.test.tsx
+++ b/packages/storybook/src/ui/organisms/card/card.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react'
 
 import Card from '@ltht-react/card'
+import { createRef } from 'react'
 
 describe('Card', () => {
   it('Renders', () => {
@@ -13,5 +14,171 @@ describe('Card', () => {
         <Card.Footer>Footer</Card.Footer>
       </Card>
     )
+  })
+
+  it('renders children correctly', () => {
+    const { getByText } = render(
+      <Card>
+        <Card.Header>Header Content</Card.Header>
+        <Card.Body>Body Content</Card.Body>
+        <Card.Footer>Footer Content</Card.Footer>
+      </Card>
+    )
+    expect(getByText('Header Content')).toBeInTheDocument()
+    expect(getByText('Body Content')).toBeInTheDocument()
+    expect(getByText('Footer Content')).toBeInTheDocument()
+  })
+
+  it('forwards ref to the root element', () => {
+    const ref = createRef<HTMLDivElement>()
+    render(
+      <Card ref={ref}>
+        <Card.Body>Body</Card.Body>
+      </Card>
+    )
+    expect(ref.current).not.toBeNull()
+    expect(ref.current?.nodeName).toBe('DIV')
+  })
+
+  it('forwards ref to Card.Body', () => {
+    const ref = createRef<HTMLDivElement>()
+    render(
+      <Card>
+        <Card.Body ref={ref}>Body</Card.Body>
+      </Card>
+    )
+    expect(ref.current).not.toBeNull()
+    expect(ref.current?.nodeName).toBe('DIV')
+    expect(ref.current?.textContent).toBe('Body')
+  })
+
+  it('forwards ref to Card.Footer', () => {
+    const ref = createRef<HTMLDivElement>()
+    render(
+      <Card>
+        <Card.Footer ref={ref}>Footer</Card.Footer>
+      </Card>
+    )
+    expect(ref.current).not.toBeNull()
+    expect(ref.current?.nodeName).toBe('DIV')
+    expect(ref.current?.textContent).toBe('Footer')
+  })
+
+  it('forwards ref to Card.Banner', () => {
+    const ref = createRef<HTMLDivElement>()
+    render(
+      <Card>
+        <Card.Banner ref={ref} status="warning">
+          Banner
+        </Card.Banner>
+      </Card>
+    )
+    expect(ref.current).not.toBeNull()
+    expect(ref.current?.nodeName).toBe('DIV')
+    expect(ref.current?.textContent).toBe('Banner')
+  })
+
+  it('renders Card.Banner content', () => {
+    const { getByText } = render(
+      <Card>
+        <Card.Banner status="warning">Banner Content</Card.Banner>
+      </Card>
+    )
+    expect(getByText('Banner Content')).toBeInTheDocument()
+  })
+
+  it('forwards ref to Card.List', () => {
+    const ref = createRef<HTMLUListElement>()
+    render(
+      <Card>
+        <Card.List ref={ref}>
+          <Card.ListItem>Item 1</Card.ListItem>
+        </Card.List>
+      </Card>
+    )
+    expect(ref.current).not.toBeNull()
+    expect(ref.current?.nodeName).toBe('UL')
+    expect(ref.current?.children.length).toBe(1)
+    expect(ref.current?.children[0].textContent).toBe('Item 1')
+  })
+
+  it('forwards ref to Card.ListItem', () => {
+    const ref = createRef<HTMLLIElement>()
+    render(
+      <Card>
+        <Card.List>
+          <Card.ListItem ref={ref}>List Item Ref</Card.ListItem>
+        </Card.List>
+      </Card>
+    )
+    expect(ref.current).not.toBeNull()
+    expect(ref.current?.nodeName).toBe('LI')
+    expect(ref.current?.textContent).toBe('List Item Ref')
+  })
+
+  it('renders Card.ListItem with correct classes', () => {
+    const { container } = render(
+      <Card>
+        <Card.List>
+          <Card.ListItem>List Item 1</Card.ListItem>
+          <Card.ListItem>List Item 2</Card.ListItem>
+        </Card.List>
+      </Card>
+    )
+    const listItems = container.querySelectorAll('.card__list-item')
+    expect(listItems.length).toBe(2)
+    expect(listItems[0].textContent).toBe('List Item 1')
+    expect(listItems[1].textContent).toBe('List Item 2')
+  })
+  it('renders Card.List with correct classes', () => {
+    const { container } = render(
+      <Card>
+        <Card.List>
+          <Card.ListItem>List Item 1</Card.ListItem>
+          <Card.ListItem>List Item 2</Card.ListItem>
+        </Card.List>
+      </Card>
+    )
+    const list = container.querySelector('.card__list')
+    expect(list).toBeInTheDocument()
+    expect(list?.children.length).toBe(2)
+    expect(list?.children[0].textContent).toBe('List Item 1')
+    expect(list?.children[1].textContent).toBe('List Item 2')
+  })
+  it('renders Card.Subtitle', () => {
+    const { getByText } = render(
+      <Card>
+        <Card.Subtitle>Subtitle Content</Card.Subtitle>
+      </Card>
+    )
+    expect(getByText('Subtitle Content')).toBeInTheDocument()
+  })
+  it('renders Card.Text', () => {
+    const { getByText } = render(
+      <Card>
+        <Card.Text>Text Content</Card.Text>
+      </Card>
+    )
+    expect(getByText('Text Content')).toBeInTheDocument()
+  })
+  it('renders Card.Title', () => {
+    const { getByText } = render(
+      <Card>
+        <Card.Title>Title Content</Card.Title>
+      </Card>
+    )
+    expect(getByText('Title Content')).toBeInTheDocument()
+  })
+  it('applies custom classes', () => {
+    const { container } = render(
+      <Card classes="custom-class">
+        <Card.Header>Header</Card.Header>
+        <Card.Body>Body</Card.Body>
+        <Card.Footer>Footer</Card.Footer>
+      </Card>
+    )
+    const card = container.querySelector('.card.custom-class')
+    expect(card).toBeInTheDocument()
+    expect(card?.classList.contains('custom-class')).toBe(true)
   })
 })

--- a/packages/styles/src/atoms/icons.ts
+++ b/packages/styles/src/atoms/icons.ts
@@ -66,6 +66,9 @@ export const iconTypes = [
   'minus-square',
   'minus-circle',
   'cross-circle',
+  'expand',
+  'expand-alt',
+  'expand-arrows-alt',
 ] as const
 
 export type IconType = (typeof iconTypes)[number]


### PR DESCRIPTION
This update adds forwardRef support to the Card and its subcomponents (Card.Header, Card.Body, Card.Footer).

- Card now forwards refs to its root DOM element for direct access (e.g., focus, scroll, measure).
- Subcomponents remain accessible via composition with full IntelliSense and type safety.
- TypeScript updated to use ReturnType<typeof forwardRef> for cleaner, maintainable typing.
- Preserves native HTML attributes and custom props on both main and subcomponents.
- Fully backward-compatible while enabling more flexible UI integration.