### PR TITLE
Update ActionMenu: Support exiting fullscreen when actions are triggered

### DIFF
--- a/components/styled/menu/package.json
+++ b/components/styled/menu/package.json
@@ -33,6 +33,7 @@
     "@ltht-react/icon": "^2.0.172",
     "@ltht-react/styles": "^2.0.172",
     "@ltht-react/utils": "^2.0.172",
+    "@ltht-react/hooks": "^2.0.172",
     "react": "^18.2.0"
   },
   "gitHead": "4d364556bb11e294d86697c2dac66742f7aabc7f"

--- a/components/styled/menu/src/molecules/action-menu-option.tsx
+++ b/components/styled/menu/src/molecules/action-menu-option.tsx
@@ -1,0 +1,110 @@
+import { useMemo, MouseEvent, memo, FC, useCallback } from 'react'
+import Icon, { IconProps } from '@ltht-react/icon'
+import { stringToHtmlId } from '@ltht-react/utils'
+import { useFullScreen } from '@ltht-react/hooks'
+import { ActionMenuOption as IActionMenuOption } from './action-menu'
+import { Menu, MenuItem } from './menu'
+
+interface Props extends IActionMenuOption {
+  idPrefix: string
+  index: number
+}
+
+// Utility function to generate consistent IDs
+const generateActionId = (idPrefix: string, text: string, index: number): string => {
+  const textId = stringToHtmlId(text)
+  return `${idPrefix}action-menu-item-${textId}-${index}`
+}
+
+// Memoized icon renderer to prevent unnecessary re-renders
+const IconRenderer = memo<{ icon?: IconProps }>(({ icon }) => {
+  if (!icon) return null
+  return <Icon {...icon} />
+})
+
+IconRenderer.displayName = 'IconRenderer'
+
+const ActionMenuOption: FC<Props> = ({
+  idPrefix,
+  index,
+  text,
+  leftIcon,
+  rightIcon,
+  actions,
+  exitFullScreenOnClick = false,
+  clickHandler,
+  onClick,
+  disabled = false,
+  ...rest
+}) => {
+  const { isFullscreen, exitFullScreen } = useFullScreen()
+
+  // Memoize the action ID to prevent recalculation on every render
+  const actionMenuItemId = useMemo(() => generateActionId(idPrefix, text, index), [idPrefix, text, index])
+
+  // Memoize icons to prevent unnecessary re-renders
+  const leftIconElement = useMemo(() => <IconRenderer icon={leftIcon} />, [leftIcon])
+
+  const rightIconElement = useMemo(() => <IconRenderer icon={rightIcon} />, [rightIcon])
+
+  const handleOnClick = useCallback(
+    async (e: MouseEvent<HTMLButtonElement>) => {
+      if (disabled) {
+        e.preventDefault()
+        return
+      }
+
+      if (!clickHandler && !onClick) {
+        return
+      }
+
+      if (exitFullScreenOnClick && isFullscreen) {
+        await exitFullScreen()
+      }
+
+      // Execute the appropriate handler
+      if (clickHandler) {
+        clickHandler()
+      } else if (onClick) {
+        onClick(e)
+      }
+    },
+    [disabled, clickHandler, onClick, exitFullScreenOnClick, isFullscreen, exitFullScreen]
+  )
+
+  // Determine if this is a submenu (has actions)
+  const isSubmenu = actions && actions.length > 0
+
+  // Common props for both Menu and MenuItem
+  const commonProps = useMemo(
+    () => ({
+      id: actionMenuItemId,
+      'data-testid': actionMenuItemId,
+      label: text,
+      leftIcon: leftIconElement,
+      rightIcon: rightIconElement,
+      disabled,
+      ...rest,
+    }),
+    [actionMenuItemId, text, leftIconElement, rightIconElement, disabled, rest]
+  )
+
+  if (isSubmenu) {
+    return (
+      <Menu {...commonProps} aria-label={`${text} submenu`} aria-expanded="false">
+        {actions.map((action, actionIndex) => (
+          <ActionMenuOption
+            key={`${actionMenuItemId}_menu_item_${actionIndex}`}
+            idPrefix={`${actionMenuItemId}_`}
+            index={actionIndex}
+            {...action}
+          />
+        ))}
+      </Menu>
+    )
+  }
+
+  return <MenuItem {...commonProps} onClick={handleOnClick} aria-label={text} />
+}
+
+export default ActionMenuOption

--- a/components/styled/menu/src/molecules/action-menu.tsx
+++ b/components/styled/menu/src/molecules/action-menu.tsx
@@ -1,9 +1,9 @@
-import { FC, HTMLAttributes, ReactNode } from 'react'
-import Icon, { IconProps } from '@ltht-react/icon'
-import { stringToHtmlId } from '@ltht-react/utils'
+import { FC, HTMLAttributes } from 'react'
+import { IconProps } from '@ltht-react/icon'
 import { ButtonProps } from '@ltht-react/button'
 
-import { Menu, MenuItem } from './menu'
+import { Menu } from './menu'
+import MenuOption from './action-menu-option'
 
 interface IProps<T extends HTMLElement = HTMLElement> extends HTMLAttributes<HTMLButtonElement> {
   actions: ActionMenuOption[]
@@ -31,6 +31,7 @@ export interface ActionMenuOption extends HTMLAttributes<HTMLButtonElement> {
   leftIcon?: IconProps
   rightIcon?: IconProps
   disabled?: boolean
+  exitFullScreenOnClick?: boolean
   actions?: ActionMenuOption[]
 }
 
@@ -53,46 +54,15 @@ const ActionMenu: FC<IProps> = ({
 
   return (
     <Menu rootTrigger={menuButtonOptions} data-testid={id} {...rest}>
-      {actions.map((action, index) => renderAction(menuItemIdPrefix, action, index))}
+      {actions.map((action, index) => (
+        <MenuOption
+          key={`${menuItemIdPrefix}_menu_item_${index}`}
+          idPrefix={menuItemIdPrefix}
+          index={index}
+          {...action}
+        />
+      ))}
     </Menu>
-  )
-}
-
-const renderAction = (
-  idPrefix: string,
-  { text, leftIcon, rightIcon, clickHandler, onClick, actions, ...rest }: ActionMenuOption,
-  index: number
-): ReactNode => {
-  const textId = stringToHtmlId(text)
-  const actionMenuItemId = `${idPrefix}action-menu-item-${textId}-${index}`
-
-  if (!!actions?.length && actions.length > 0) {
-    return (
-      <Menu
-        key={actionMenuItemId}
-        id={actionMenuItemId}
-        data-testid={actionMenuItemId}
-        label={text}
-        leftIcon={leftIcon ? <Icon {...leftIcon} /> : null}
-        rightIcon={rightIcon ? <Icon {...rightIcon} /> : null}
-        {...rest}
-      >
-        {actions.map((action, index) => renderAction(actionMenuItemId, action, index))}
-      </Menu>
-    )
-  }
-
-  return (
-    <MenuItem
-      key={actionMenuItemId}
-      id={actionMenuItemId}
-      data-testid={actionMenuItemId}
-      label={text}
-      leftIcon={leftIcon ? <Icon {...leftIcon} /> : null}
-      rightIcon={rightIcon ? <Icon {...rightIcon} /> : null}
-      onClick={clickHandler ?? onClick}
-      {...rest}
-    />
   )
 }
 

--- a/packages/storybook/src/ui/organisms/generic-table/generic-table.mockdata.tsx
+++ b/packages/storybook/src/ui/organisms/generic-table/generic-table.mockdata.tsx
@@ -233,6 +233,7 @@ export const buildActionsForQuestionnaire = (id: string, actions: string[]): Adm
       console.log(`${id}: ${x} action clicked!`)
     },
     leftIcon: { type: 'info-circle', size: 'medium', color: 'info-blue' },
+    exitFullScreenOnClick: true,
   })),
 })
 


### PR DESCRIPTION
Updates to ActionMenu component by adding support for fullscreen-aware actions.

When the app is in fullscreen mode, menu actions can now request to exit fullscreen automatically before executing their option logic.

Ensures a smoother user experience by preventing menus and dialogs from being hidden behind fullscreen contexts.

Backward compatible: existing actions continue to work without requiring changes.