### PR TITLE
Fix pre-1970 PartialDateTime formatting to preserve correct calendar date

### DIFF
--- a/packages/storybook/src/clinical/organisms/diagnosis/diagnosis.fixtures.tsx
+++ b/packages/storybook/src/clinical/organisms/diagnosis/diagnosis.fixtures.tsx
@@ -967,6 +967,85 @@ const ConditionSeven: Condition = {
   ],
 }
 
+const ConditionEight: Condition = {
+  id: 'R3|b8612fe0-a596-4fbd-a4c9-5be4e8bfb2b3',
+  abatement: null,
+  assertedDate: {
+    kind: PartialDateTimeKindCode.DateTime,
+    value: '1753-01-01T00:00:15+00:00',
+  },
+  category: [],
+  bodySite: [],
+  identifier: [
+    {
+      system: 'https://leedsth.nhs.uk/cds/instance-identifier',
+      value: 'ce89b057-6d53-4335-885f-d02e70a60b4a',
+      extension: null,
+    },
+    {
+      system: 'https://leedsth.nhs.uk/cds/instance-set-identifier',
+      value: 'b8612fe0-a596-4fbd-a4c9-5be4e8bfb2b3',
+      extension: null,
+    },
+    {
+      system: 'https://leedsth.nhs.uk/cds/root-instance-identifier',
+      value: 'a2568b3c-eb37-49bf-b73a-6b4e304ae28b',
+      extension: null,
+    },
+  ],
+  extensionData: null,
+  note: [],
+  evidence: null,
+  asserter: null,
+  stage: null,
+  code: {
+    coding: [
+      {
+        code: '27031003',
+        display: 'African trypanosomiasis',
+      },
+    ],
+    text: 'African trypanosomiasis',
+  },
+  clinicalStatus: ConditionClinicalStatus.Active,
+  metadata: {
+    isRedacted: false,
+    dataSources: [
+      {
+        code: 'EHR',
+        display: 'PPM+',
+      },
+    ],
+    tag: [
+      {
+        code: null,
+        display: 'diagnosis-level-one',
+        system: 'https://leedsth.nhs.uk/cds/root-template-name',
+      },
+      {
+        code: null,
+        display: 'Problems & Diagnosis',
+        system: 'https://leedsth.nhs.uk/cds/root-template-display-name',
+      },
+      {
+        code: null,
+        display: 'Provisional, African trypanosomiasis: Active',
+        system: 'https://leedsth.nhs.uk/cds/snippet-text',
+      },
+      {
+        code: null,
+        display: 'Provisional, African trypanosomiasis: Active',
+        system: 'https://leedsth.nhs.uk/cds/snippet-hover-text',
+      },
+    ],
+    requestedWhen: '',
+  },
+  onset: null,
+  severity: null,
+  verificationStatus: ConditionVerificationStatus.Provisional,
+  extension: [],
+}
+
 const conditions: Condition[] = [
   ConditionOne,
   ConditionThree,
@@ -976,6 +1055,7 @@ const conditions: Condition[] = [
   ConditionTwo,
   ConditionSix,
   ConditionSeven,
+  ConditionEight,
 ]
 
 const controls: ButtonProps[] = [

--- a/packages/storybook/src/clinical/organisms/diagnosis/diagnosis.stories.tsx
+++ b/packages/storybook/src/clinical/organisms/diagnosis/diagnosis.stories.tsx
@@ -1,4 +1,4 @@
-import { Story } from '@storybook/react'
+import { Story, StoryObj } from '@storybook/react'
 
 import DiagnosisSummary from '@ltht-react/diagnosis-summary'
 import DiagnosisDetail from '@ltht-react/diagnosis-detail'
@@ -76,6 +76,21 @@ export const Summary: Story = () => {
       </Card.List>
     </Card>
   )
+}
+
+export const SummaryDateOnly: StoryObj = {
+  render: () => (
+    <Card>
+      <Card.Header>
+        <Card.Title>Problems & Diagnosis</Card.Title>
+      </Card.Header>
+      <Card.List>
+        <Card.ListItem>
+          <DiagnosisSummary condition={conditions[8]} isReadOnly={false} dateOnlyView />
+        </Card.ListItem>
+      </Card.List>
+    </Card>
+  ),
 }
 
 export const Redacted: Story = () => (

--- a/packages/utils/src/atoms/partial-date-time.test.ts
+++ b/packages/utils/src/atoms/partial-date-time.test.ts
@@ -2,14 +2,14 @@ import { PartialDateTime, PartialDateTimeKindCode } from '@ltht-react/types'
 import { formatDateTime, partialDateTimeText, formatPartialDateTimeAsDateOnly } from './partial-date-time'
 
 describe('partialDateTimeText', () => {
-  // it('formats date correctly', () => {
-  //   const date = partialDateTime(PartialDateTimeKindCode.Date)
-  //   expect(partialDateTimeText(date)).toEqual('03-Feb-2013')
-  // })
-  // it('formats date-time correctly', () => {
-  //   const date = partialDateTime(PartialDateTimeKindCode.DateTime)
-  //   expect(partialDateTimeText(date)).toEqual('03-Feb-2013 13:15')
-  // })
+  it('formats date correctly', () => {
+    const date = partialDateTime(PartialDateTimeKindCode.Date)
+    expect(partialDateTimeText(date)).toEqual('03-Feb-2013')
+  })
+  it('formats date-time correctly', () => {
+    const date = partialDateTime(PartialDateTimeKindCode.DateTime)
+    expect(partialDateTimeText(date)).toEqual('03-Feb-2013 13:15')
+  })
   it('formats time correctly', () => {
     const date = partialDateTime(PartialDateTimeKindCode.Time)
     expect(partialDateTimeText(date)).toEqual('13:15')
@@ -41,6 +41,86 @@ describe('partialDateTimeText', () => {
   it('formats DateTimes to show date portion only in DD-MMM-YYYY format', () => {
     const date = partialDateTime(PartialDateTimeKindCode.DateTime)
     expect(formatPartialDateTimeAsDateOnly(date)).toEqual('03-Feb-2013')
+  })
+})
+
+describe('formatPartialDateTimeAsDateOnly', () => {
+  it('formats a standard date-time correctly', () => {
+    const date: PartialDateTime = {
+      value: '2013-02-03T13:15:16+00:00',
+      kind: PartialDateTimeKindCode.DateTime,
+    }
+    expect(formatPartialDateTimeAsDateOnly(date)).toEqual('03-Feb-2013')
+  })
+
+  it('formats a pre-1970 date correctly', () => {
+    const date: PartialDateTime = {
+      value: '1950-07-15T10:30:00+00:00',
+      kind: PartialDateTimeKindCode.DateTime,
+    }
+    expect(formatPartialDateTimeAsDateOnly(date)).toEqual('15-Jul-1950')
+  })
+
+  it('formats a far future date correctly', () => {
+    const date: PartialDateTime = {
+      value: '2099-12-31T23:59:59+00:00',
+      kind: PartialDateTimeKindCode.DateTime,
+    }
+    expect(formatPartialDateTimeAsDateOnly(date)).toEqual('31-Dec-2099')
+  })
+
+  it('formats the edge case 1753-01-01T00:00:15+00:00 correctly', () => {
+    const date: PartialDateTime = {
+      value: '1753-01-01T00:00:15+00:00',
+      kind: PartialDateTimeKindCode.DateTime,
+    }
+    expect(formatPartialDateTimeAsDateOnly(date)).toEqual('01-Jan-1753')
+  })
+
+  it.each([
+    { date: '1899-01-01T00:00:00Z', expected: '01-Jan-1899' },
+    { date: '1753-01-01T00:00:00Z', expected: '01-Jan-1753' },
+    { date: '2024-01-01T00:00:00Z', expected: '01-Jan-2024' },
+    { date: '2024-01-01T00:00:00+00:00', expected: '01-Jan-2024' },
+    { date: '2024-04-01T00:00:00+00:00', expected: '01-Apr-2024' },
+    { date: '1753-01-01T00:00:15+00:00', expected: '01-Jan-1753' },
+    { date: '1900-01-01T00:00:00+00:00', expected: '01-Jan-1900' },
+    { date: '1899-01-01T00:00:00+00:00', expected: '01-Jan-1899' },
+    { date: '1800-01-01T00:00:00+00:00', expected: '01-Jan-1800' },
+    { date: '0001-01-01T00:00:00+00:00', expected: '01-Jan-0001' },
+    { date: '0001-01-01T00:00:00+00:00', expected: '01-Jan-0001' },
+    { date: '1000-06-15T12:30:00+00:00', expected: '15-Jun-1000' },
+    { date: '1500-12-31T23:59:59+00:00', expected: '31-Dec-1500' },
+    { date: '1753-01-01T00:00:00+00:00', expected: '01-Jan-1753' },
+    { date: '1753-01-01T00:00:15+00:00', expected: '01-Jan-1753' },
+    { date: '1969-12-31T23:59:59+01:00', expected: '31-Dec-1969' },
+    { date: '1970-01-01T00:00:00+00:00', expected: '01-Jan-1970' },
+    { date: '1999-12-31T12:00:00+00:00', expected: '31-Dec-1999' },
+    { date: '2000-01-01T00:00:00+00:00', expected: '01-Jan-2000' },
+    { date: '2023-08-20T14:30:00+00:00', expected: '20-Aug-2023' },
+    { date: '2025-12-31T23:59:59+00:00', expected: '31-Dec-2025' },
+  ])('formats a range of dates correctly: %s', (props) => {
+    const date: PartialDateTime = {
+      value: props.date,
+      kind: PartialDateTimeKindCode.DateTime,
+    }
+    expect(formatPartialDateTimeAsDateOnly(date)).toEqual(props.expected)
+  })
+
+  it('returns empty string for undefined', () => {
+    expect(formatPartialDateTimeAsDateOnly(undefined)).toEqual('')
+  })
+
+  it('returns empty string for null', () => {
+    expect(formatPartialDateTimeAsDateOnly(null)).toEqual('')
+  })
+
+  it('returns empty string for missing value', () => {
+    const date: PartialDateTime = {
+      value: '',
+      kind: PartialDateTimeKindCode.DateTime,
+    }
+    expect(formatPartialDateTimeAsDateOnly(date)).toEqual('')
   })
 })
 

--- a/packages/utils/src/atoms/partial-date-time.ts
+++ b/packages/utils/src/atoms/partial-date-time.ts
@@ -1,5 +1,5 @@
 import { PartialDateTime, PartialDateTimeKindCode } from '@ltht-react/types'
-import { format, parseISO } from 'date-fns'
+import { format, parseISO, isMatch } from 'date-fns'
 
 const locale = 'en-gb'
 const dayFormat = '2-digit'
@@ -20,6 +20,38 @@ export const formatTime = (date: Date): string =>
 
 export const formatDateTime = (date: Date): string => `${formatDateExplicitMonth(date)} : ${formatTime(date)}`
 
+/**
+ * Converts a PartialDateTime object into a human-readable string based on its kind.
+ *
+ * Handles different kinds of partial date/time information:
+ * - `Date`        → returns date only (formatted using `formatDate`)
+ * - `DateTime`    → returns date and time (formatted using `formatDate` + `formatTime`)
+ * - `Year`        → returns the year (formatted using `toLocaleString` with year options)
+ * - `YearMonth`   → returns year-month (formatted with locale, joined with '-')
+ * - `Time`        → returns time only (formatted using `formatTime`)
+ *
+ * If `partialDateTime` is `null`, `undefined`, or the value is missing, returns an empty string.
+ *
+ * @param partialDateTime - A PartialDateTime object containing a value and a kind
+ * @returns A human-readable string representing the date/time according to its kind,
+ *          or an empty string if the input is missing or unrecognized.
+ *
+ * @example
+ * partialDateTimeText({ value: '2023-08-20', kind: PartialDateTimeKindCode.Date })
+ * // returns "20-Aug-2023" (depending on formatDate implementation)
+ *
+ * partialDateTimeText({ value: '2023-08-20T14:30:00', kind: PartialDateTimeKindCode.DateTime })
+ * // returns "20-Aug-2023 14:30" (depending on formatDate/formatTime)
+ *
+ * partialDateTimeText({ value: '2023', kind: PartialDateTimeKindCode.Year })
+ * // returns "2023"
+ *
+ * partialDateTimeText({ value: '2023-08', kind: PartialDateTimeKindCode.YearMonth })
+ * // returns "Aug-2023"
+ *
+ * partialDateTimeText({ value: '14:30:00', kind: PartialDateTimeKindCode.Time })
+ * // returns "14:30"
+ */
 export const partialDateTimeText = (partialDateTime?: PartialDateTime | null): string => {
   if (!partialDateTime || !partialDateTime.value) {
     return ''
@@ -45,9 +77,65 @@ export const partialDateTimeText = (partialDateTime?: PartialDateTime | null): s
   }
 }
 
+/**
+ * Formats a PartialDateTime object into a display string ("dd-MMM-yyyy").
+ *
+ * For dates after 1970, the full ISO string is parsed normally.
+ * For dates in 1970 or earlier, the `formatLegacyIsoDate` function is used
+ * to avoid local timezone shifts that could cause off-by-one-day errors.
+ *
+ * @param partialDateTime - A PartialDateTime object containing an ISO 8601 string value
+ * @returns A formatted date string in "dd-MMM-yyyy" format, or an empty string
+ *          if the input is null, undefined, or missing a value.
+ *
+ * @example
+ * formatPartialDateTimeAsDateOnly({ value: '1753-01-01T00:00:15+00:00' })
+ * // returns "01-Jan-1753"
+ *
+ * formatPartialDateTimeAsDateOnly({ value: '2023-08-20T14:30:00+01:00' })
+ * // returns "20-Aug-2023"
+ */
 export const formatPartialDateTimeAsDateOnly = (partialDateTime?: PartialDateTime | null): string => {
   if (!partialDateTime?.value) return ''
 
-  const date = parseISO(partialDateTime.value)
+  const isoString = partialDateTime.value
+
+  const year = Number(isoString.substring(0, 4))
+
+  if (year > 1969) {
+    const date = parseISO(isoString)
+    return format(date, 'dd-MMM-yyyy')
+  }
+
+  return formatLegacyIsoDate(isoString)
+}
+
+/**
+ * Formats a pre-1970 ISO date string to a human-readable "dd-MMM-yyyy" format.
+ *
+ * This function handles historical dates safely by:
+ * - Using only the first 10 characters (`YYYY-MM-DD`) of the ISO string
+ *   to ignore time and timezone components.
+ * - Ensuring the date is parsed correctly without local timezone adjustments,
+ *   preventing off-by-one-day errors.
+ *
+ * @param isoString - An ISO 8601 date string (e.g., "1753-01-01T00:00:15+00:00")
+ * @returns A formatted date string in "dd-MMM-yyyy" format, or an empty string
+ *          if the input is invalid or incomplete.
+ *
+ * @example
+ * formatLegacyIsoDate('1753-01-01T00:00:15+00:00')
+ * // returns "01-Jan-1753"
+ */
+export const formatLegacyIsoDate = (isoString: string): string => {
+  const datePart = isoString.slice(0, 10)
+
+  if (datePart.length !== 10) return ''
+
+  // ensure we have a valid date part
+  if (!isMatch(datePart, 'yyyy-MM-dd')) return ''
+
+  const date = parseISO(datePart)
+  // parse the date part and format it as "dd-MMM-yyyy"
   return format(date, 'dd-MMM-yyyy')
 }


### PR DESCRIPTION
This PR updates the `formatPartialDateTimeAsDateOnly` and `formatLegacyIsoDate` functions 
to correctly format historical dates (pre-1970) without local timezone shifts.

Changes:
- For dates after 1970, ISO strings are parsed normally.
- For pre-1970 dates, only the date portion (`YYYY-MM-DD`) of the ISO string is used,
  avoiding off-by-one-day errors caused by timezone conversions.
- Added detailed JSDoc comments explaining the rationale and usage.

This ensures accurate display of historical and legacy dates, including SQL Server 
minimum date values (e.g., 1753-01-01).