### PR TITLE
Type gen to update LaunchPermission

### DIFF
--- a/packages/types/src/atoms/graphql-types.ts
+++ b/packages/types/src/atoms/graphql-types.ts
@@ -2999,7 +2999,7 @@ export enum LaunchApp {
 /** Permission to launch one or more Apps with the given Intents. */
 export type LaunchPermission = {
   /** The App the user can launch. */
-  application: LaunchApp;
+  applications: Array<LaunchApp>;
   /** Unique id for inter-element referencing. */
   elementId?: Maybe<Scalars['String']>;
   /** Additional content defined by implementations. */


### PR DESCRIPTION
As part of the XForms work, we need to be able to say that a given resource could be permitted to launch in several applications.