### PR TITLE
added types for new patientRecordEvent graphql call

### DIFF
--- a/packages/types/src/atoms/graphql-types.ts
+++ b/packages/types/src/atoms/graphql-types.ts
@@ -1376,6 +1376,8 @@ export type Ehr = {
   patientGroup?: Maybe<Group>;
   /** Patient History */
   patientHistory?: Maybe<PatientHistoryArticleContinuation>;
+  /** Patient Record Event */
+  patientRecordEvent?: Maybe<PatientRecordEvent>;
   /** Patient Record Events */
   patientRecordEvents?: Maybe<PatientRecordEventContinuation>;
   /** Patient Search by Free Text */
@@ -1740,6 +1742,13 @@ export type EhrPatientGroupArgs = {
 export type EhrPatientHistoryArgs = {
   count?: Maybe<Scalars['Int']>;
   cursorToken?: Maybe<Scalars['String']>;
+  patientGuid: Scalars['String'];
+};
+
+
+/** Queries the LTHT EHR. */
+export type EhrPatientRecordEventArgs = {
+  eventGuid: Scalars['String'];
   patientGuid: Scalars['String'];
 };
 
@@ -3581,6 +3590,8 @@ export type PatientRecordEvent = {
   identifier?: Maybe<Array<Maybe<Identifier>>>;
   /** Flag to state whether the resource should be displayed as entered in error in user interface */
   isEnteredInError?: Maybe<Scalars['Boolean']>;
+  /** The launch type of this patient record. e.g. (Cds, XForm, PPMDocStore, Cito, etc) */
+  launchType?: Maybe<PatientRecordLaunchTypeCode>;
   /** Metadata about the resource. */
   metadata: Metadata;
   /** Who, What, When for a set of resources. */
@@ -3608,6 +3619,17 @@ export type PatientRecordEventContinuation = {
   /** The total number of resources available (if known). */
   totalResources?: Maybe<Scalars['Int']>;
 };
+
+/** Enumeration of possible record launch types for a patient record. */
+export enum PatientRecordLaunchTypeCode {
+  Cds = 'CDS',
+  Cito = 'CITO',
+  ClinicalView = 'CLINICAL_VIEW',
+  Pathway = 'PATHWAY',
+  PpmDocStore = 'PPM_DOC_STORE',
+  Unknown = 'UNKNOWN',
+  XForm = 'X_FORM'
+}
 
 /** Enumeration of possible statuses for a patient record. */
 export enum PatientRecordStatusCode {


### PR DESCRIPTION
A launchType prop was added to PatientRecordEvent to allow the frontend to determine the specific launch method to use.

Resource data is now included in the resource property, reusing the same properties across different launch types, with some variations in the resource URI format and by adding CDS information to the resource’s extension for consistency.

Together, these changes ensure the resource can be launched correctly while flexible enough to be extended for other launch types e.g. cito.